### PR TITLE
Removing the support of coverall.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,8 @@ matrix:
       env: PUPPET_VERSION="~> 3.2.0"
     - rvm: 2.1.0
       env: PUPPET_VERSION="~> 3.3.0"
-    # coveralls.io not compatible with ruby < 1.9.3
     - rvm: 1.8.7
-      env: PUPPET_VERSION="~> 3.8.0" COVERAGE=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
+      env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
     # Puppet 4.0.0 requires ruby 1.9.3 or greater.
     - rvm: 1.8.7
       env: PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,3 @@ group :system_tests do
   gem "beaker"
   gem "beaker-rspec"
 end
-
-if ENV['COVERAGE'] == 'yes'
-  gem 'coveralls', :require => false
-end

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,6 @@
 # Aptly Puppet module
 
 [![TravisBuild](https://travis-ci.org/tubemogul/puppet-aptly.svg?branch=master)](https://travis-ci.org/tubemogul/puppet-aptly)
-[![Coverage Status](https://coveralls.io/repos/tubemogul/puppet-aptly/badge.svg)](https://coveralls.io/r/tubemogul/puppet-aptly)
 
 Puppet forge statistics:
 [![Puppet Forge downloads](https://img.shields.io/puppetforge/dt/TubeMogul/aptly.svg)](https://forge.puppetlabs.com/TubeMogul/aptly)

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,1 +1,0 @@
-at_exit { RSpec::Puppet::Coverage.report! }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,1 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-# coveralls.io integration
-if ENV['COVERAGE'] == 'yes'
-  require 'coveralls'
-  Coveralls.wear!
-end


### PR DESCRIPTION
Hi,

This PR is to remove the usage of coveralls.io here. The reasons is that:
 * coveralls.io don't properly support puppet-rspec's coverage features (only the results of the .rb files are properly taken in account)
 * The 3rd party libraries we use like the apt module have some ruby scripts that have a test coverage that got lower, which lowered our result and make the coverage checks fail even if the test coverage of this module is still properly handled.

Thanks
Joseph