### PR TITLE
Removing the integration of coveralls.io and updating travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,21 @@
 language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-script: bundle exec rake test --trace
 env:
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.3"
-  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.1.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.2.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.3.0" STRICT_VARIABLES=yes
+rvm:
+  - 1.9.3
+  - 2.0
+  - 2.1
+  - 2.2
+script: bundle exec rake test
 matrix:
   exclude:
-    # https://github.com/puppetlabs/puppet/commit/d02820a116d5e3ae0b129a0b4384ddaf76f0f83b 
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.2.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.3.0"
-    # Puppet 4.0.0 requires ruby 1.9.3 or greater.
-    - rvm: 1.8.7
-      env: PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
+    - rvm: 2.2
+      env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
+    - rvm: 2.2
+      env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 3.8.0" COVERAGE=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
   - PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
 matrix:
   exclude:
@@ -25,9 +25,6 @@ matrix:
       env: PUPPET_VERSION="~> 3.2.0"
     - rvm: 2.1.0
       env: PUPPET_VERSION="~> 3.3.0"
-    # coveralls.io not compatible with ruby < 1.9.3
-    - rvm: 1.8.7
-      env: PUPPET_VERSION="~> 3.8.0" COVERAGE=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
     # Puppet 4.0.0 requires ruby 1.9.3 or greater.
     - rvm: 1.8.7
       env: PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,3 @@ group :system_tests do
   gem "beaker"
   gem "beaker-rspec"
 end
-
-if ENV['COVERAGE'] == 'yes'
-  gem 'coveralls', :require => false
-end

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,6 @@
 # Aptly Puppet module
 
 [![TravisBuild](https://travis-ci.org/tubemogul/puppet-aptly.svg?branch=master)](https://travis-ci.org/tubemogul/puppet-aptly)
-[![Coverage Status](https://coveralls.io/repos/tubemogul/puppet-aptly/badge.svg)](https://coveralls.io/r/tubemogul/puppet-aptly)
 
 Puppet forge statistics:
 [![Puppet Forge downloads](https://img.shields.io/puppetforge/dt/TubeMogul/aptly.svg)](https://forge.puppetlabs.com/TubeMogul/aptly)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,1 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
-
-# coveralls.io integration
-if ENV['COVERAGE'] == 'yes'
-  require 'coveralls'
-  Coveralls.wear!
-end


### PR DESCRIPTION
Coveralls.io does not really integrate very well with Puppet code code coverage, so I propose to remove it to get less noise.