### PR TITLE
Redo documentation and move to a params.pp for default values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+2016-XX-XX Release 2.0.0
+- Adding documentation
+- Adding the possiblity of setting up mirrors, snapshots and publications
+directly via puppet
+- Adding the management of the API
+- The following parameters have been renamed for a better coherence:
+aptly::rootDir => aptly::root_dir (was already available with this name in hiera),
+aptly::config_arch => aptly::architectures (was already available with this name in hiera),
+aptly::config_props => aptly::properties (was already available with this name in hiera),
+aptly::s3publishpson => aptly::s3_publish_endpoints (was available under aptly::s3PublishEndpoints in hiera before)
 2015-07-03 Release 1.0.2
 - Adding CI public tools integration
 - Cleaning up the different supported versions

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
 Joseph Herlant (aerostitch)
 Julien Fabre (pryz)
 Nicolas Brousse (orieg)
+Mykola Mogylenko (mmogylenko)

--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,8 @@
     * [Setup requirements](#setup-requirements)
     * [Beginning with aptly](#beginning-with-aptly)
 4. [Usage - Configuration options and additional functionality](#usage)
+    * [Basic example](#basic-example)
+    * [Enable aptly API endpoint](#enable-aptly-api-endpoint)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
   * [Public classes and defines](#public-classes-and-defines)
   * [Private classes](#private-classes)
@@ -35,7 +37,7 @@ What is this module capable to do?
  * Install the aptly package in a specific version (or just the latest available)
  * Manage a specific user and group (with their corresponding fixed uid/gid) dedicated to the service
  * Configure a specific debian repository (optional) where to find the package
- * Manage the /etc/aptly.conf file
+ * Manage the `/etc/aptly.conf` file
  * Enable/start or disable the service
  * Enable/start or disable the API
  * Manages the init.d service file
@@ -53,15 +55,15 @@ layer in addition to this module.
 
 Files managed by the module:
 
- * /etc/aptly.conf
- * /etc/apt/sources.list.d/aptly.list (optional)
- * /etc/init.d/aptly
+ * `/etc/aptly.conf`
+ * `/etc/apt/sources.list.d/aptly.list` (optional)
+ * `/etc/init.d/aptly`
 
 ### Setup Requirements
 
 The module requires:
- - [Puppetlabs stdlib](https://github.com/puppetlabs/puppetlabs-stdlib.git)
- - [Puppetlab's APT module](https://github.com/puppetlabs/puppetlabs-apt.git) at least version 2.0.x
+ * [Puppetlabs stdlib](https://github.com/puppetlabs/puppetlabs-stdlib.git)
+ * [Puppetlab's APT module](https://github.com/puppetlabs/puppetlabs-apt.git) at least version 2.0.x
 
 ### Beginning with aptly
 
@@ -78,21 +80,76 @@ puppet module install tubemogul/aptly
 
 ## Usage
 
-Basic usage example:
-```
-class { 'aptly': }
+Those examples include the puppet-only configuration, and the corresponding
+configuration for those who use hiera (I find it more convenient for copy/paste
+of a full configuration when you have both - yes, I'm lazy ;-) ).
+
+### Basic example
+
+The default values are normally sane enough to do as few parameters overwrites
+as possible.
+
+But let's say you want:
+ * Aptly to store its data in `/data` (that you created before hand)
+ * to only have the architectures `i386` and `amd64`
+ * to have your ppa codename to be `foo`
+
+Then you just do:
+```puppet
+class { 'aptly':
+  root_dir      => '/data',
+  architectures => ['i386', 'amd64'],
+  ppa_codename  => 'foo',
+}
 ```
 
-NOTE: this will also install the official aptly repo in your sources.list.d.
+Or using hiera:
+```yaml
+---
+aptly::root_dir: /data
+aptly::architectures:
+  - i386
+  - amd64
+aptly::ppa_codename: foo
+```
+
+**NOTE:** this will also install the official aptly repo in your sources.list.d.
+
+### Enable aptly API endpoint
+
+To:
+ * enable the aptly API management
+ * make it listen on port `42000`
+ * have it listen on the private interface of your server (let's say this interface has `10.0.0.123` AS IP)
+ * have started with no-lock mode as you are doing both cli and API calls
+
+Then you can do:
+```puppet
+class { 'aptly':
+  enable_api => true,
+  api_port   => 42000,
+  api_bind   => '10.0.0.123',
+  api_nolock => true,
+}
+```
+
+Or using hiera:
+```yaml
+---
+aptly::enable_api: true
+aptly::api_port: 42000
+aptly::api_nolock: 10.0.0.123
+aptly::api_nolock: true
+```
 
 ## Reference
 
 ### Public classes and defines
 
  * [`aptly`](#class-aptly): Installs and configures the aptly server.
- * [`aptly::mirror`](#define-aptly--mirror): Manages an aptly mirror.
- * [`aptly::snapshot`](#define-aptly--snapshot): Manages an aptly snapshot.
- * [`aptly::publish`](#define-aptly--publish): Manages an aptly publication.
+ * [`aptly::mirror`](#define-aptlymirror): Manages an aptly mirror.
+ * [`aptly::snapshot`](#define-aptlysnapshot): Manages an aptly snapshot.
+ * [`aptly::publish`](#define-aptlypublish): Manages an aptly publication.
 
 ### Private classes
 
@@ -400,5 +457,12 @@ it.
 
 ## Development
 
-See the CONTRIBUTING.md file.
+We're actually nice people and we rarely bite, so you're more than welcome to
+contribute to our repos via the usual GitHub PR and issues.
+
+What we ask generally is that when you push a change or a new functionnality,
+you add the corresponding tests at the same time. You'll find a lot of tests
+examples in this repository.
+
+See the [CONTRIBUTING.md](https://github.com/tubemogul/puppet-aptly/blob/master/CONTRIBUTING.md) file for more detailed guidelines.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,8 @@
 # Aptly Puppet module
 
 [![TravisBuild](https://travis-ci.org/tubemogul/puppet-aptly.svg?branch=master)](https://travis-ci.org/tubemogul/puppet-aptly)
-
-Puppet forge statistics:
-[![Puppet Forge downloads](https://img.shields.io/puppetforge/dt/TubeMogul/aptly.svg)](https://forge.puppetlabs.com/TubeMogul/aptly)
 [![Puppet Forge latest release](https://img.shields.io/puppetforge/v/TubeMogul/aptly.svg)](https://forge.puppetlabs.com/TubeMogul/aptly)
+[![Puppet Forge downloads](https://img.shields.io/puppetforge/dt/TubeMogul/aptly.svg)](https://forge.puppetlabs.com/TubeMogul/aptly)
 [![Puppet Forge score](https://img.shields.io/puppetforge/f/TubeMogul/aptly.svg)](https://forge.puppetlabs.com/TubeMogul/aptly/scores)
 
 #### Table of Contents
@@ -17,6 +15,10 @@ Puppet forge statistics:
     * [Beginning with aptly](#beginning-with-aptly)
 4. [Usage - Configuration options and additional functionality](#usage)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
+  * [Public classes and defines](#public-classes-and-defines)
+  * [Private classes](#private-classes)
+  * [Providers and types](#providers-and-types)
+  * [Parameters](#parameters)
 5. [Limitations - OS compatibility, etc.](#limitations)
 6. [Development - Guide for contributing to the module](#development)
 
@@ -24,28 +26,23 @@ Puppet forge statistics:
 
 This module installs the [aptly](www.aptly.info) Deb package repository manager and configures it.
 
-It has been tested and used in production with:
-
- * Puppet 3.7 on Ubuntu 14.04 (trusty)
-
-The spec tests pass against puppet 3.{2,3,4,5,6,7} including the future parser.
-
-We had to drop the compatibility with Puppet 2.7 as we are using puppetlabs/apt
-module version >= 2.x which is not compatible with this version of Puppet.
+Need help of want a new feature? File an issue on our github repository: https://github.com/tubemogul/puppet-maxscale/issues
 
 ## Module Description
 
 What is this module capable to do?
 
- * Install the aptly package in a specific version
+ * Install the aptly package in a specific version (or just the latest available)
  * Manage a specific user and group (with their corresponding fixed uid/gid) dedicated to the service
  * Configure a specific debian repository (optional) where to find the package
  * Manage the /etc/aptly.conf file
- * Enable/start or disable the service (you can specify this in hiera)
+ * Enable/start or disable the service
+ * Enable/start or disable the API
  * Manages the init.d service file
+ * Manage apt mirrors, snapshots, publications
  
-The aptly service will listen on port 80 on every interfaces using the
-`aptly serve -listen=":80"` command.
+The aptly service will listen on port 80 on every interfaces (configurable) using the `aptly serve -listen=":80"` command.
+
 If you want to make the repository beeing served by an apache, nginx or whatever
 else, just disable the service and setup the http server you want for the HTTP(S)
 layer in addition to this module.
@@ -53,12 +50,6 @@ layer in addition to this module.
 ## Setup
 
 ### What aptly affects
-
-Warning:
-
- * This module don't manage your mirrors or repos. It manages the installation,
-   configuration and start/stop of the service. The creation of the mirrors is
-   on your plate.
 
 Files managed by the module:
 
@@ -70,8 +61,7 @@ Files managed by the module:
 
 The module requires:
  - [Puppetlabs stdlib](https://github.com/puppetlabs/puppetlabs-stdlib.git)
- - [Puppetlab's APT module](https://github.com/puppetlabs/puppetlabs-apt.git) at
-   least version 2.0.x
+ - [Puppetlab's APT module](https://github.com/puppetlabs/puppetlabs-apt.git) at least version 2.0.x
 
 ### Beginning with aptly
 
@@ -95,15 +85,320 @@ class { 'aptly': }
 
 NOTE: this will also install the official aptly repo in your sources.list.d.
 
+## Reference
+
+### Public classes and defines
+
+ * [`aptly`](#class-aptly): Installs and configures the aptly server.
+ * [`aptly::mirror`](#define-aptly--mirror): Manages an aptly mirror.
+ * [`aptly::snapshot`](#define-aptly--snapshot): Manages an aptly snapshot.
+ * [`aptly::publish`](#define-aptly--publish): Manages an aptly publication.
+
+### Private classes
+
+ * `aptly::install`: Installs the aptly server.
+ * `aptly::config`: Configures the aptly server.
+ * `aptly::service`: Manages the aptly server and the API services.
+
+### Providers and types
+
+To manage the aptly resources, this modules embeds the following custom
+types and corresponding providers (to be accessed via the public defines):
+
+ * `aptly_mirror` to manage an aptly mirror
+ * `aptly_snapshot` to manage an aptly snapshot
+ * `aptly_publish` to manage an aptly publication
+
+### Parameters
+
+#### Class aptly
+
+##### `version`
+
+Aptly version to ensure to install.
+You can use a version number to force a version or just use `installed` or
+`latest` to benefit from the usual Puppet behavior.
+
+Default: `installed`
+
+##### `install_repo`
+
+Boolean to manage wether or not you want to have a sources.list repo
+managed by the module.
+
+Default: `true`
+
+##### `repo_location`
+
+Location of the remote repo to manage when using `install_repo` to `true`.
+
+Default: `http://repo.aptly.info`
+
+##### `repo_release`
+
+Release of the repo to use when using `install_repo` to `true`.
+
+Default: `squeeze`
+
+##### `repo_repos`
+
+Repo name to use in the repo when using `install_repo` to `true`.
+
+Default: `main`
+
+##### `repo_keyserver`
+
+Key server to use to retreive the key of the repo when using `install_repo`
+to `true`.
+
+Default: `keys.gnupg.net`
+
+##### `repo_key`
+
+Key used by the signed repo when using `install_repo` to `true`.
+
+Default: `DF32BC15E2145B3FA151AED19E3E53F19C7DE460`
+
+##### `enable_service`
+
+Boolean to enable or disable the service.
+
+Default: `true` (service enabled)
+
+##### `port`
+
+Port for the Aptly webserver
+
+Default : `80`
+
+##### `bind`
+
+IP address of the Aptly webserver (`0.0.0.0` or empty string meaning that you
+listen on all interfaces).
+
+Default: `0.0.0.0`
+
+##### `config_filepath`
+
+Path of the configuration file to be used by the aptly service.
+
+Default: `/etc/aptly.conf`
+
+##### `user`
+
+OS user which will run the service.
+
+Default: `aptly`
+
+##### `uid`
+
+UID of the OS user which will run the service.
+
+Default: `450`
+
+##### `group`
+
+Group of the OS user which will run the service.
+
+Default: `aptly`
+
+##### `gid`
+
+GID of the group of the OS user which will run the service.
+
+Default: `450`
+
+##### `root_dir`
+
+Root directory to use as root for storing the repo data.
+
+Default: `/var/aptly`
+
+##### `architectures`
+
+Architectures managed by the repo.
+
+Default: `[]` (empty means all architectures)
+
+##### `ppa_dist`
+
+Distribution code of the ppa to serve.
+
+Default: `ubuntu`
+
+##### `ppa_codename`
+
+Codename of the ppa to serve.
+
+Default: `''`
+
+
+##### `properties`
+
+Hash containing the optional properties of the aptly.conf. The key is the
+property name and the value is its value!
+
+Default:
+
+```
+{
+  'downloadConcurrency'         => 4,
+  'downloadSpeedLimit'          => 0,
+  'dependencyFollowSuggests'    => false,
+  'dependencyFollowRecommends'  => false,
+  'dependencyFollowAllVariants' => false,
+  'dependencyFollowSource'      => false,
+  'gpgDisableSign'              => false,
+  'gpgDisableVerify'            => false,
+  'downloadSourcePackages'      => false,
+}
+```
+
+
+##### `s3_publish_endpoints`
+
+Hash to describe the s3PublishEndpoints property of the aptly.conf.
+
+Default: `{}`
+
+##### `enable_api`
+
+Enable Aptly API by starting the service
+
+Default : `false`
+
+##### `api_port`
+
+Port for the Aptly API service.
+
+Default : `8080`
+
+##### `api_bind`
+
+Binding address for the Aptly API service.
+
+Default : `0.0.0.0`
+
+##### `api_nolock`
+
+If `true`, the API service will not lock the database (for situations where you
+heavily use both the API and the cli for example).
+
+Default : `false`
+
+
+#### Define aptly::mirror
+
+##### `location`
+
+Location of the repository to mirror.
+
+Default: `undef`
+
+##### `ensure`
+
+Ensures if the mirror must be `present` (should exist) or `absent` (or be
+destroyed).
+
+Default: `present`
+
+##### `distribution`
+
+Distribution to mirror.
+
+Default: `$::lsbdistcodename`
+
+##### `architectures`
+
+Architectures to mirror.
+
+Default: `[]`
+
+##### `components`
+
+Components to mirror.
+
+Default: `[]`
+
+##### `with_sources`
+
+Mirror the sources or not.
+
+Default: `false`
+
+##### `with_udebs`
+
+Download the .udeb packages.
+
+Default: `false`
+
+#### Define aptly::snapshot
+
+##### `source_type`
+
+Type of source to snapshot. Correct values are:
+
+ * `mirror`
+ * `repo`
+ * `empty`
+
+Default: `undef`
+
+##### `source_name`
+
+Name of the source to create snapshot from.
+
+Default: `undef`
+
+##### `ensure`
+
+Ensures if the snapshot must be `present` (should exist) or `absent` (or be
+destroyed).
+
+Default: `present`
+
+#### Define aptly::publish
+
+##### `source_type`
+
+Type of source to publish. Supported values are:
+
+ * `repo`
+ * `snapshot`
+
+Default: `undef`
+
+##### `source_name`
+
+Name of the source to publish.
+
+Default: `undef`
+
+##### `ensure`
+
+Ensures if the publication must be `present` (should exist) or `absent` (or be
+destroyed).
+
+Default: `present`
+
+
+
+## Limitations
+
+This module has been tested against Puppet 3.8 with Ubuntu clients.
+
+The spec tests work on Puppet 3.7+ and 4.x.
+
+To work on Debian OS family servers, it requires the apt module from Puppetlabs
+to be installed if you want to have this module manage your aptly repository (optionnal).
+
+The implementation for the installation on other operating systems has not been
+done yet but should be pretty straightforward to do. Just ask which one you want
+and we'll add it or submit a pull request on our github page and we'll integrate
+it.
+
+
 ## Development
 
 See the CONTRIBUTING.md file.
 
-## TODO
-
-There are still some work to do on this module including:
-
- * write acceptance tests
- * write smoke tests
- * test the module against other platforms
- * test against puppet 4

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
 # == Class aptly::config
 #
-# This class is called from aptly for service config.
+# This class is called from the aptly class for service configuration.
 #
 class aptly::config {
 
@@ -16,7 +16,7 @@ class aptly::config {
     content => template('aptly/aptly.conf.erb'),
   }
 
-  file { $aptly::rootDir:
+  file { $aptly::root_dir:
     ensure => directory,
     mode   => '0755',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,146 +1,34 @@
 # == Class: aptly
 #
-# Main class to manage Aptly repo manager.
-# Only tested on Ubuntu Trusty and Puppet 3.7 but designed to also be compatible
-# Puppet 2.7 for now.
+# Main class. See README.markdown for more documentation.
 #
-# === Parameters
-#
-# [*version*]
-#   Aptly version to ensure to install.
-#   You can use a version number to force a version
-#   or just use 'installed' (default) or 'latest' to have the usual Puppet
-#   behavior.
-#
-# [*install_repo*]
-#   Boolean to manage wether or not you want to have a sources.list repo
-#   managed by the module.
-#
-# [*repo_location*]
-#   Location of the remote repo to manage when using 'install_repo' to true.
-#   Defaults to the official aptly repo (http://repo.aptly.info).
-#
-# [*repo_release*]
-#   Release of the repo to use when using 'install_repo' to true.
-#   Default to squeeze which is the default stable version for the debian-based
-#   installations.
-#
-# [*repo_repos*]
-#   Repo name to use in the repo when using 'install_repo' to true.
-#   Defaults to 'main'.
-#
-# [*repo_keyserver*]
-#   Key server to use to retreive the key of the repo when using 'install_repo'
-#   to true.
-#   Defaults to 'keys.gnupg.net'.
-#
-# [*repo_key*]
-#   Key used by the signed repo when using 'install_repo' to true.
-#   Default is 'B6140515643C2AE155596690E083A3782A194991' which is currently
-#   the fingerprint of the key used in the official Aptly APT repository.
-#
-# [*enable_service*]
-#   Boolean to enable or disable the service.
-#   Defaults to true (service enabled)
-#
-# [*port*]
-#   Port for the Aptly webserver
-#   Default : 80
-#
-# [*bind*]
-#   IP address of the Aptly webserver
-#   Default : 0.0.0.0
-#
-# [*user*]
-#   OS user which will run the service. Default is aptly.
-#   Defaults to 'aptly'.
-#
-# [*uid*]
-#   UID of the OS user which will run the service. Default is aptly.
-#   Defaults to 450.
-#
-# [*group*]
-#   Group of the OS user which will run the service. Default is aptly.
-#   Defaults to 'aptly'.
-#
-# [*gid*]
-#   GID of the group of the OS user which will run the service. Default is aptly.
-#   Defaults to 450.
-#
-# [*rootDir*]
-#   Root directory to use as root for storing the repo data.
-#
-# [*config_arch*]
-#   Architectures managed by the repo. Empty means all.
-#   Defaults to all.
-#
-# [*ppa_dist*]
-#   Distribution code of the ppa to serve. Defaults to ubuntu.
-#
-# [*ppa_codename*]
-#   Codename of the ppa to serve. Defaults to ubuntu.
-#
-# [*config_props*]
-#   Hash containing the optional properties of the aptly.conf.
-#
-# [*s3publishpson*]
-#   Hash to describe the s3PublishEndpoints property of the aptly.conf.
-#   Defaults to empty.
-#
-# [*enable_api*]
-#   Enable Aptly API by starting the service
-#   Default : false
-#
-# [*api_port*]
-#   Port for the Aptly API service.
-#   Default : 8080
-#
-# [*api_bind*]
-#   Binding address for the Aptly API service.
-#   Default : 0.0.0.0
-#
-# [*api_nolock*]
-#   If true, the API service will not lock the database
-#   Default : false
-#
-
 class aptly (
-  $version         = hiera('aptly::version', 'installed'),
-  $install_repo    = hiera('aptly::install_repo', true),
-  $repo_location   = hiera('aptly::repo_location', 'http://repo.aptly.info'),
-  $repo_release    = hiera('aptly::repo_release', 'squeeze'),
-  $repo_repos      = hiera('aptly::repo_repos', 'main'),
-  $repo_keyserver  = hiera('aptly::repo_keyserver', 'keys.gnupg.net'),
-  $repo_key        = hiera('aptly::repo_key', 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460'),
-  $enable_service  = hiera('aptly::enable_service', true),
-  $port            = hiera('aptly::port', '80'),
-  $bind            = hiera('aptly::bind', '0.0.0.0'),
-  $config_filepath = hiera('aptly::config_filepath', '/etc/aptly.conf'),
-  $user            = hiera('aptly::user', 'aptly'),
-  $uid             = hiera('aptly::uid', 450),
-  $group           = hiera('aptly::group', 'aptly'),
-  $gid             = hiera('aptly::gid', 450),
-  $rootDir         = hiera('aptly::root_dir', '/var/aptly'),
-  $config_arch     = hiera('aptly::architectures', []),
-  $ppa_dist        = hiera('aptly::ppa_dist', 'ubuntu'),
-  $ppa_codename    = hiera('aptly::ppa_codename', ''),
-  $config_props    = hiera('aptly::properties', {
-    'downloadConcurrency'         => 4,
-    'downloadSpeedLimit'          => 0,
-    'dependencyFollowSuggests'    => false,
-    'dependencyFollowRecommends'  => false,
-    'dependencyFollowAllVariants' => false,
-    'dependencyFollowSource'      => false,
-    'gpgDisableSign'              => false,
-    'gpgDisableVerify'            => false,
-    'downloadSourcePackages'      => false,
-    }),
-  $s3publishpson   = hiera('aptly::s3PublishEndpoints', {}),
-  $enable_api      = hiera('aptly::enable_api', false),
-  $api_port        = hiera('aptly::api_port', 8080),
-  $api_bind        = hiera('aptly::api_bind', '0.0.0.0'),
-  $api_nolock      = hiera('aptly::api_nolock', false),
-) {
+  $version              = $aptly::params::version,
+  $install_repo         = $aptly::params::install_repo,
+  $repo_location        = $aptly::params::repo_location,
+  $repo_release         = $aptly::params::repo_release,
+  $repo_repos           = $aptly::params::repo_repos,
+  $repo_keyserver       = $aptly::params::repo_keyserver,
+  $repo_key             = $aptly::params::repo_key,
+  $enable_service       = $aptly::params::enable_service,
+  $port                 = $aptly::params::port,
+  $bind                 = $aptly::params::bind,
+  $config_filepath      = $aptly::params::config_filepath,
+  $user                 = $aptly::params::user,
+  $uid                  = $aptly::params::uid,
+  $group                = $aptly::params::group,
+  $gid                  = $aptly::params::gid,
+  $root_dir             = $aptly::params::root_dir,
+  $architectures        = $aptly::params::architectures,
+  $ppa_dist             = $aptly::params::ppa_dist,
+  $ppa_codename         = $aptly::params::ppa_codename,
+  $properties           = $aptly::params::properties,
+  $s3_publish_endpoints = $aptly::params::s3_publish_endpoints,
+  $enable_api           = $aptly::params::enable_api,
+  $api_port             = $aptly::params::api_port,
+  $api_bind             = $aptly::params::api_bind,
+  $api_nolock           = $aptly::params::api_nolock,
+) inherits aptly::params {
 
   validate_string(
     $version,
@@ -153,7 +41,7 @@ class aptly (
     $config_filepath,
     $user,
     $group,
-    $rootDir)
+    $root_dir)
   if ! is_integer($uid) { fail("invalid ${uid} provided") }
   if ! is_integer($gid) { fail("invalid ${gid} provided") }
   validate_re($repo_key, '^[A-F0-9]+$')
@@ -162,9 +50,9 @@ class aptly (
     $enable_service,
     $enable_api,
     $api_nolock)
-  validate_array($config_arch)
-  validate_hash($config_props)
-  validate_hash($s3publishpson)
+  validate_array($architectures)
+  validate_hash($properties)
+  validate_hash($s3_publish_endpoints)
   validate_integer(
     $port,
     $api_port

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,6 @@
 # == Class aptly::install
 #
-# This class is called from aptly for install.
+# This class is called from the aptly class for installing the service.
 #
 class aptly::install {
 

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -1,7 +1,6 @@
 # == Define aptly::mirror
 #
-# This definition is meant to be called from aptly.
-# It manages APT Mirrors.
+# Manages an apt mirror.
 #
 define aptly::mirror (
   $location,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,42 @@
+# == Class: aptly::params
+#
+# Just holding the default values of the module. To overwrite something, do it
+# on the target class.
+#
+class aptly::params {
+  $version         = 'installed'
+  $install_repo    = true
+  $repo_location   = 'http://repo.aptly.info'
+  $repo_release    = 'squeeze'
+  $repo_repos      = 'main'
+  $repo_keyserver  = 'keys.gnupg.net'
+  $repo_key        = 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460'
+  $enable_service  = true
+  $port            = '80'
+  $bind            = '0.0.0.0'
+  $config_filepath = '/etc/aptly.conf'
+  $user            = 'aptly'
+  $uid             = 450
+  $group           = 'aptly'
+  $gid             = 450
+  $root_dir        = '/var/aptly'
+  $architectures   = []
+  $ppa_dist        = 'ubuntu'
+  $ppa_codename    = ''
+  $properties      = {
+    'downloadConcurrency'         => 4,
+    'downloadSpeedLimit'          => 0,
+    'dependencyFollowSuggests'    => false,
+    'dependencyFollowRecommends'  => false,
+    'dependencyFollowAllVariants' => false,
+    'dependencyFollowSource'      => false,
+    'gpgDisableSign'              => false,
+    'gpgDisableVerify'            => false,
+    'downloadSourcePackages'      => false,
+    }
+  $s3_publish_endpoints = {}
+  $enable_api           = false
+  $api_port             = 8080
+  $api_bind             = '0.0.0.0'
+  $api_nolock           = false
+}

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -1,5 +1,7 @@
 # == Define aptly::publish
 #
+# Manages the aptly publications (of repos, mirrors and snapshots)
+#
 define aptly::publish (
   $source_type,
   $source_name = $name,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,7 @@
 # == Class aptly::service
 #
-# This class is meant to be called from aptly.
-# It ensure the service is running.
+# This class is meant to be called by the aptly class.
+# It ensure the services are in the desired state.
 #
 class aptly::service {
 

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -122,7 +122,7 @@ describe 'aptly', :type => :class do
           :group           => 'repogrp',
           :gid             => 666,
           :config_filepath => '/home/aptly/.aptly.cfg',
-          :rootDir         => '/aptly',
+          :root_dir        => '/aptly',
         }}
 
         it { is_expected.to contain_package('aptly').with_ensure('installed').with_provider('apt') }
@@ -246,19 +246,19 @@ describe 'aptly', :type => :class do
 
     # Testing the parameters related to the config
     context 'limiting to specific architectures' do
-      let(:params) {{ :config_arch => ['amd64', 'i386'] }}
+      let(:params) {{ :architectures => ['amd64', 'i386'] }}
       it { should create_file('/etc/aptly.conf').with_content(/"architectures": \["amd64", "i386"\],/) }
     end
 
     context 'using custom config properties' do
-      let(:params) {{ :config_props => { 'gpgDisableVerify' => 'true', } }}
+      let(:params) {{ :properties => { 'gpgDisableVerify' => 'true', } }}
       it { should create_file('/etc/aptly.conf').with_content(/"gpgDisableVerify": true,/) }
       # Should not have the default values
       it { should_not create_file('/etc/aptly.conf').with_content(/"gpgDisableSign": false,/) }
     end
 
     context 'adding an s3 publish endpoint' do
-      let(:params) {{ :s3publishpson => {
+      let(:params) {{ :s3_publish_endpoints => {
         'test' => {
           'region'             => 'us-east-1',
           'bucket'             => 'repo',

--- a/templates/aptly.conf.erb
+++ b/templates/aptly.conf.erb
@@ -1,10 +1,10 @@
 {
-  "rootDir": "<%= scope.lookupvar('aptly::rootDir') -%>",
-  "architectures": ["<%= scope.lookupvar('aptly::config_arch').join('", "') %>"],
-  <% scope.lookupvar('aptly::config_props').each do |k, v| -%>
+  "rootDir": "<%= scope.lookupvar('aptly::root_dir') -%>",
+  "architectures": ["<%= scope.lookupvar('aptly::architectures').join('", "') %>"],
+  <% scope.lookupvar('aptly::properties').each do |k, v| -%>
     "<%=k -%>": <%=v%>,
   <% end -%>
   "ppaDistributorID": "<%= scope.lookupvar('aptly::ppa_dist') %>",
   "ppaCodename": "<%= scope.lookupvar('aptly::ppa_codename') %>",
-  "S3PublishEndpoints": <%= scope.lookupvar('aptly::s3publishpson').to_pson %>
+  "S3PublishEndpoints": <%= scope.lookupvar('aptly::s3_publish_endpoints').to_pson %>
 }


### PR DESCRIPTION
This PR includes:
 * documentation enhancements
 * renaming of some parameters for better coherence
 * moving the default values to a params.pp (and getting rid of the hiera calls as we dropped the support for puppet3, so we have the autolookup)