### PR TITLE
Forcing the -config parameter in the aptly init.d

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -78,11 +78,11 @@ class aptly::install {
   }
 
   $nolock = $aptly::api_nolock ? {
-    true  => '--no-lock-true',
-    false => '',
+    true  => 'true',
+    false => 'false',
   }
 
-  $api_opts = "--listen ${aptly::api_bind}:${aptly::api_port} ${nolock}"
+  $api_opts = "--listen ${aptly::api_bind}:${aptly::api_port} -no-lock=${nolock}"
 
   file{ '/etc/init.d/aptly-api':
     ensure  => present,

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -310,10 +310,23 @@ describe 'aptly', :type => :class do
       let(:params) {{ :api_bind => 'I_AM_A_BAD_IP' }}
       it { should raise_error(Puppet::Error, /API Bind IP address is not correct/)}
     end
+
     context 'Enable API service' do
       let(:params)  {{ :enable_api => true }}
       it { should contain_service('aptly-api')\
         .with_ensure('running')
+      }
+    end
+
+    context 'Enable no-lock on the API' do
+      let(:params)  {{ :enable_api => true, :api_nolock => true }}
+      it { is_expected.to contain_service('aptly-api').with_ensure('running') }
+
+      it { is_expected.to create_file('/etc/init.d/aptly-api')\
+        .with_mode('0744')\
+        .with_owner('root')\
+        .with_group('root')\
+        .with_content(/-no-lock=true/)
       }
     end
   end

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -53,7 +53,8 @@ describe 'aptly', :type => :class do
             .with_mode('0744')\
             .with_owner('root')\
             .with_group('root')\
-            .with_content(/^DAEMON_USER=aptly$/)
+            .with_content(/^DAEMON_USER=aptly$/)\
+            .with_content(/-config=\\"\/etc\/aptly.conf\\"/)
         end
 
         it do
@@ -164,6 +165,11 @@ describe 'aptly', :type => :class do
             .with_mode('0644')\
             .with_owner('reposvc')\
             .with_group('repogrp')
+        end
+
+        it do
+          is_expected.to create_file('/etc/init.d/aptly')\
+            .with_content(/-config=\\"\/home\/aptly\/.aptly.cfg\\"/)
         end
 
         it do

--- a/templates/aptly.init.d.erb
+++ b/templates/aptly.init.d.erb
@@ -14,7 +14,7 @@ NAME=aptly
 DESC="Aptly service"
 PIDFILE=/var/run/${NAME}.pid
 DAEMON=/usr/bin/aptly
-DAEMON_OPTS="serve --listen=\"<%= scope.lookupvar('aptly::bind') %>:<%= scope.lookupvar('aptly::port') %>\""
+DAEMON_OPTS="serve --listen=\"<%= scope.lookupvar('aptly::bind') %>:<%= scope.lookupvar('aptly::port') %>\" -config=\"<%= scope.lookupvar('aptly::config_filepath') %>\""
 DAEMON_USER=<%= scope.lookupvar('aptly::user') %>
 
 [ -f /etc/default/${NAME} ] && . /etc/default/${NAME}


### PR DESCRIPTION
If there is an aptly config file in `~/.aptly.conf`, or that you want the aptly service started with something else than `~/.aptly.conf` or `/etc/aptly.conf`, you might end up with the service started without the config file you want.
This PR fixes that case.

This issue also fixes a problem in the declaration of the no-lock flag in the aptly-api service.