### PR TITLE
Fix integer validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,10 +53,8 @@ class aptly (
   validate_array($architectures)
   validate_hash($properties)
   validate_hash($s3_publish_endpoints)
-  validate_integer(
-    $port,
-    $api_port
-  )
+  validate_integer($port, 49150)
+  validate_integer($api_port, 49150)
   validate_re(
     $bind,
     '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$',


### PR DESCRIPTION
validate_integer() takes an integer or list of integers as the first
parameter, and an upper bound as the second parameter. Setting $api_port
to a low value restricts the range of $port. Fix this by doing two
validations, against the largest registrable (non-dynamic) TCP port
number.

Signed-off-by: Hugo Mills <hugo@nightglass.co.uk>