### PR TITLE
Several fixes + update in documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,6 +18,7 @@
     * [Enable aptly API endpoint](#enable-aptly-api-endpoint)
     * [Create an apt mirror](#create-an-apt-mirror)
     * [Create and drop apt repositories](#create-and-drop-apt-repositories)
+    * [Create an aptly snapshot](#create-an-aptly-snapshot)
 5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
   * [Public classes and defines](#public-classes-and-defines)
   * [Private classes](#private-classes)
@@ -255,6 +256,23 @@ aptly::repo {'my_custom_repo':
 # Making sure that the 'tubemogul_apps' exists with the expected parameters
 aptly::repo {'tubemogul_apps':
   default_component => 'stable',
+}
+```
+
+Once you've done that, you can add packages using the `aptly repo add tubemogul_apps my_package.deb` or using the API.
+
+### Create an aptly snapshot
+
+Once you've created your repo and added packages to it, you might want to take a
+snapshot of a stable stack or a coherent ensemble to publish it later.
+
+This example creates a snapshot named `nightly_20160823` based on the repository
+`tubemogul_apps` that we created in the previous example:
+
+```puppet
+aptly::snapshot { 'nightly_20160823':
+  source_type => 'repository',
+  source_name => 'tubemogul_apps',
 }
 ```
 

--- a/lib/puppet/provider/aptly_mirror/cli.rb
+++ b/lib/puppet/provider/aptly_mirror/cli.rb
@@ -50,10 +50,10 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
 
     Puppet_X::Aptly::Cli.execute(
       object: :mirror,
-      action: 'show',
-      arguments: [ name ],
+      action: 'list',
+      flags: { 'raw' => 'true' },
       exceptions: false,
-    ) !~ /ERROR/
+    ).lines.map(&:chomp).include? name
   end
 
 end

--- a/lib/puppet/provider/aptly_publish/cli.rb
+++ b/lib/puppet/provider/aptly_publish/cli.rb
@@ -31,7 +31,12 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
   def exists?
     Puppet.debug("Check if #{name} exists")
 
-    Puppet_X::Aptly::Cli.execute(object: :publish, action: 'list').lines.map(&:chomp).flatten.include? name
+    Puppet_X::Aptly::Cli.execute(
+      object: :publish,
+      action: 'list',
+      flags: { 'raw' => 'true' },
+      exceptions: false,
+    ).lines.map(&:chomp).include? name
   end
 
 end

--- a/lib/puppet/provider/aptly_repo/cli.rb
+++ b/lib/puppet/provider/aptly_repo/cli.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:aptly_repo).provide(:cli) do
   mk_resource_methods
 
   def create
-    Puppet.info("Creating Aptly Repository #{name}}")
+    Puppet.info("Creating Aptly Repository #{name}")
 
     Puppet_X::Aptly::Cli.execute(
       object: :repo,

--- a/lib/puppet/provider/aptly_snapshot/cli.rb
+++ b/lib/puppet/provider/aptly_snapshot/cli.rb
@@ -43,10 +43,10 @@ Puppet::Type.type(:aptly_snapshot).provide(:cli) do
 
     Puppet_X::Aptly::Cli.execute(
       object: :snapshot,
-      action: 'show',
-      arguments: [ name ],
+      action: 'list',
+      flags: { 'raw' => 'true' },
       exceptions: false,
-    ) !~ /ERROR/
+    ).lines.map(&:chomp).include? name
   end
 
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,8 +17,9 @@ class aptly::config {
   }
 
   file { $aptly::root_dir:
-    ensure => directory,
-    mode   => '0755',
+    ensure  => directory,
+    mode    => '0755',
+    recurse => true,
   }
 
 }

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -109,7 +109,8 @@ describe 'aptly', :type => :class do
             .with_ensure('directory')\
             .with_mode('0755')\
             .with_owner('aptly')\
-            .with_group('aptly')
+            .with_group('aptly')\
+            .with_recurse(true)
         end
       end
     end

--- a/spec/unit/puppet/provider/aptly_mirror_spec.rb
+++ b/spec/unit/puppet/provider/aptly_mirror_spec.rb
@@ -81,14 +81,23 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
   end
 
   describe '#exists?' do
-    it 'should check the mirrors list' do
-      Puppet_X::Aptly::Cli.expects(:execute).with(
+    it 'should check the mirror list' do
+      Puppet_X::Aptly::Cli.stubs(:execute).with(
         object: :mirror,
-        action: 'show',
-        arguments: ['debian-main'],
+        action: 'list',
+        flags: { 'raw' => 'true' },
         exceptions: false,
-      )
-      provider.exists?
+      ).returns "foo\ndebian-main\nbar"
+      expect(provider.exists?).to eq(true)
+    end
+    it 'should handle without mirror' do
+      Puppet_X::Aptly::Cli.stubs(:execute).with(
+        object: :mirror,
+        action: 'list',
+        flags: { 'raw' => 'true' },
+        exceptions: false,
+      ).returns ''
+      expect(provider.exists?).to eq(false)
     end
   end
 

--- a/spec/unit/puppet/provider/aptly_publish_spec.rb
+++ b/spec/unit/puppet/provider/aptly_publish_spec.rb
@@ -48,6 +48,8 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
         object: :publish,
         action: 'list',
+        flags: { 'raw' => 'true' },
+        exceptions: false,
       ).returns "foo\ntest-snap\nbar"
       expect(provider.exists?).to eq(true)
     end
@@ -55,6 +57,8 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
         object: :publish,
         action: 'list',
+        flags: { 'raw' => 'true' },
+        exceptions: false,
       ).returns ''
       expect(provider.exists?).to eq(false)
     end

--- a/spec/unit/puppet/provider/aptly_snapshot_spec.rb
+++ b/spec/unit/puppet/provider/aptly_snapshot_spec.rb
@@ -44,13 +44,22 @@ describe Puppet::Type.type(:aptly_snapshot).provider(:cli) do
   end
 
   describe '#exists?' do
-    it 'should check the snapshots list' do
+    it 'should check the snapshot list' do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
         object: :snapshot,
-        action: 'show',
-        arguments: ['2016-07-30-daily'],
+        action: 'list',
+        flags: { 'raw' => 'true' },
         exceptions: false,
-      ).returns 'ERROR Unable to ...'
+      ).returns "foo\n2016-07-30-daily\nbar"
+      expect(provider.exists?).to eq(true)
+    end
+    it 'should handle without snapshot' do
+      Puppet_X::Aptly::Cli.stubs(:execute).with(
+        object: :snapshot,
+        action: 'list',
+        flags: { 'raw' => 'true' },
+        exceptions: false,
+      ).returns ''
       expect(provider.exists?).to eq(false)
     end
   end


### PR DESCRIPTION
I committed different patches when I was in the plane, so pushing different stuffs in a single PR even if it's not the best practices...

This PR includes:
 * Fixing typo in an info message when creating a repo
 * Adding an example of aptly::snapshot to the README
 * Better handling of the exists? function in the providers, plus getting it uniform. There were some issues with that leading to recreation of resources every time you run puppet.
 * When running aptly as a non-root user, we must be careful of having the right permissions defined on the repo as the deamon running as non-root user will not be able to use the config created via puppet by root.