### PR TITLE
Management of package xz-utils

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -479,6 +479,12 @@ heavily use both the API and the cli for example).
 
 Default : `false`
 
+##### `manage_xz_utils`
+
+Boolean to enable or disable installation of the xz-utils package (required
+dependency for aptly).
+
+Default : `true`
 
 #### Define aptly::mirror
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class aptly (
   $api_port             = $aptly::params::api_port,
   $api_bind             = $aptly::params::api_bind,
   $api_nolock           = $aptly::params::api_nolock,
+  $manage_xz_utils      = $aptly::params::manage_xz_utils,
 ) inherits aptly::params {
 
   validate_string(

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -65,6 +65,12 @@ class aptly::install {
     }
   }
 
+  if $aptly::manage_xz_utils == true {
+    package { 'xz-utils':
+      ensure => present,
+    }
+  }
+
   package { 'aptly':
     ensure   => $aptly::version,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,4 +39,5 @@ class aptly::params {
   $api_port             = 8080
   $api_bind             = '0.0.0.0'
   $api_nolock           = false
+  $manage_xz_utils      = true
 }


### PR DESCRIPTION
This commit adds a new package ressource "xz-utils" to the module.

Output from aptly on a system w/o xz available:
```
root@aptly01:~# aptly publish snapshot dev_debian-jessie-main
Loading packages...
Generating metadata files and linking package files...
panic: unable to unxz data.tar.xz from /var/aptly/pool/4b/1b/fonts-ipafont-gothic_00303-12_all.deb: exec: "xz": executable file not found in $PATH [recovered]
        panic: unable to unxz data.tar.xz from /var/aptly/pool/4b/1b/fonts-ipafont-gothic_00303-12_all.deb: exec: "xz": executable file not found in $PATH

goroutine 1 [running]:
github.com/smira/aptly/cmd.Run.func1(0xc820171f18)
        /Users/smira/Documents/go/src/github.com/smira/aptly/cmd/run.go:16 +0x7f
github.com/smira/aptly/deb.(*Package).CalculateContents(0xc821308fc0, 0x7fade18a0ac0, 0xc820f07620, 0x0, 0x0, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/deb/package.go:427 +0x1b4
github.com/smira/aptly/deb.(*PackageCollection).loadContents(0xc820f07760, 0xc821308fc0, 0x7fade18a0ac0, 0xc820f07620, 0x0, 0x0, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/deb/package_collection.go:183 +0x37b
github.com/smira/aptly/deb.(*Package).Contents(0xc821308fc0, 0x7fade18a0ac0, 0xc820f07620, 0x0, 0x0, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/deb/package.go:410 +0x75
github.com/smira/aptly/deb.(*ContentsIndex).Push(0xc821554a50, 0xc821308fc0, 0x7fade18a0ac0, 0xc820f07620)
        /Users/smira/Documents/go/src/github.com/smira/aptly/deb/contents.go:26 +0x4a
github.com/smira/aptly/deb.(*PublishedRepo).Publish.func1(0xc821308fc0, 0x0, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/deb/publish.go:568 +0x8d5
github.com/smira/aptly/deb.(*PackageList).ForEachIndexed(0xc820f04fc0, 0xc820171508, 0x0, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/deb/list.go:169 +0xed
github.com/smira/aptly/deb.(*PublishedRepo).Publish(0xc820184f70, 0x7fade18a0ac0, 0xc820f07620, 0x7fade18a0b78, 0xc8200cd3f0, 0xc820159fc0, 0x7fade18a0a68, 0xc820d48ba0, 0x7fade18a0b08, 0xc820f033b0, ...)
        /Users/smira/Documents/go/src/github.com/smira/aptly/deb/publish.go:593 +0x1135
github.com/smira/aptly/cmd.aptlyPublishSnapshotOrRepo(0xc82015e480, 0xc820159e20, 0x1, 0x2, 0x0, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/cmd/publish_snapshot.go:145 +0x14fd
github.com/smira/commander.(*Command).Dispatch(0xc82015e480, 0xc820159e20, 0x1, 0x2, 0x0, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/_vendor/src/github.com/smira/commander/commands.go:305 +0x647
github.com/smira/commander.(*Command).Dispatch(0xc82015e7e0, 0xc820159e10, 0x2, 0x3, 0x0, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/_vendor/src/github.com/smira/commander/commands.go:283 +0x1f0
github.com/smira/commander.(*Command).Dispatch(0xc82015efc0, 0xc820159e00, 0x3, 0x4, 0x0, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/_vendor/src/github.com/smira/commander/commands.go:283 +0x1f0
github.com/smira/aptly/cmd.Run(0xc82015efc0, 0xc82000a1d0, 0x3, 0x3, 0xd3ed01, 0x0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/cmd/run.go:40 +0x19a
main.main()
        /Users/smira/Documents/go/src/github.com/smira/aptly/main.go:9 +0x73

goroutine 6 [syscall]:
os/signal.loop()
        /usr/local/Cellar/go/1.5.3/libexec/src/os/signal/signal_unix.go:22 +0x18
created by os/signal.init.1
        /usr/local/Cellar/go/1.5.3/libexec/src/os/signal/signal_unix.go:28 +0x37

goroutine 7 [runnable]:
github.com/syndtr/goleveldb/leveldb/util.(*BufferPool).drain(0xc820144380)
        /Users/smira/Documents/go/src/github.com/smira/aptly/_vendor/src/github.com/syndtr/goleveldb/leveldb/util/buffer_pool.go:206 +0x29d
created by github.com/syndtr/goleveldb/leveldb/util.NewBufferPool
        /Users/smira/Documents/go/src/github.com/smira/aptly/_vendor/src/github.com/syndtr/goleveldb/leveldb/util/buffer_pool.go:237 +0x26b

goroutine 21 [sleep]:
time.Sleep(0xbebc200)
        /usr/local/Cellar/go/1.5.3/libexec/src/runtime/time.go:59 +0xf9
github.com/cheggaaa/pb.(*ProgressBar).writer(0xc8231605a0)
        /Users/smira/Documents/go/src/github.com/smira/aptly/_vendor/src/github.com/cheggaaa/pb/pb.go:332 +0x5b
created by github.com/cheggaaa/pb.(*ProgressBar).Start
        /Users/smira/Documents/go/src/github.com/smira/aptly/_vendor/src/github.com/cheggaaa/pb/pb.go:101 +0x9c

```