### PR TITLE
Fix hiera definition for aptly API

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -151,7 +151,7 @@ Or using hiera:
 ---
 aptly::enable_api: true
 aptly::api_port: 42000
-aptly::api_nolock: 10.0.0.123
+aptly::api_bind: 10.0.0.123
 aptly::api_nolock: true
 ```
 


### PR DESCRIPTION
This PR fixes a small typo on the readme for the hiera definitions of aptly API