### PR TITLE
Add support for Debian 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,11 +9,16 @@
   "issues_url": "https://github.com/tubemogul/puppet-aptly/issues",
   "operatingsystem_support": [
     {
-      "operatingsystem":
-      "Ubuntu",
-      "operatingsystemrelease":
-      [
-        "14.04","16.04"
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
+        "16.04"
       ]
     }
   ],


### PR DESCRIPTION
Please add support for Debian 8.x or the Puppet Forge will not show this module, if you set the filter Operating System to Debian. 