### PR TITLE
Fix permissions of recurse directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,7 +18,7 @@ class aptly::config {
 
   file { $aptly::root_dir:
     ensure  => directory,
-    mode    => '0755',
+    mode    => '0644',
     recurse => true,
   }
 

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -107,7 +107,7 @@ describe 'aptly', :type => :class do
         it do
           should create_file('/var/aptly')\
             .with_ensure('directory')\
-            .with_mode('0755')\
+            .with_mode('0644')\
             .with_owner('aptly')\
             .with_group('aptly')\
             .with_recurse(true)
@@ -177,7 +177,7 @@ describe 'aptly', :type => :class do
         it do
           should create_file('/aptly')\
             .with_ensure('directory')\
-            .with_mode('0755')\
+            .with_mode('0644')\
             .with_owner('reposvc')\
             .with_group('repogrp')
         end


### PR DESCRIPTION
This prevents files from beeing executable. Puppet will handle the execution bit for directories on its own. 