### PR TITLE
Lower the size of the test matrix in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,16 @@
 language: ruby
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
-env:
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.1.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.2.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.3.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.4.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.5.0" STRICT_VARIABLES=yes
-rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
 script: bundle exec rake test
 matrix:
-  exclude:
-    - rvm: 2.2
-      env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-    - rvm: 2.2
-      env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
+  include:
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" FUTURE_PARSER="yes"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES=yes
+  - rvm: 2.2.6
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES=yes
+  - rvm: 2.3.3
+    env: PUPPET_VERSION="~> 4.0" STRICT_VARIABLES=yes


### PR DESCRIPTION
This commit lower the size of the test matrix in travis to speed up the test process as requested in #33 .
Currently the tests are taking about 53mins with 26 environments.
This change brings the test matrix to 5 environments which should be pretty sufficient for now.