### PR TITLE
Deleting contributors file as it is easy to get ot from the github api

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,0 @@
-Joseph Herlant (aerostitch)
-Julien Fabre (pryz)
-Nicolas Brousse (orieg)
-Mykola Mogylenko (mmogylenko)
-Simon Lauger(slauger)


### PR DESCRIPTION
I very often forget to update the CONTRIBUTORS file. It's not in most of the repos anymore anyway.
And you can get it anytime at: api.github.com/repos/tubemogul/puppet-aptly/contributors
So let's get rid of it.