### PR TITLE
Add support for parameter distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,11 +594,11 @@ Type of source to publish. Supported values are:
 
 Default: `undef`
 
-##### `source_name`
+##### `distribution`
 
-Name of the source to publish.
+Distribution name to publish.
 
-Default: `undef`
+Default: `"${::lsbdistcodename}-${name}"`
 
 ##### `ensure`
 

--- a/lib/puppet/provider/aptly_publish/cli.rb
+++ b/lib/puppet/provider/aptly_publish/cli.rb
@@ -12,7 +12,8 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
     Puppet_X::Aptly::Cli.execute(
       object: :publish,
       action: resource[:source_type],
-      arguments: [name]
+      arguments: [name],
+      flags: { 'distribution' => resource[:distribution] }
     )
   end
 

--- a/lib/puppet/type/aptly_publish.rb
+++ b/lib/puppet/type/aptly_publish.rb
@@ -20,4 +20,14 @@ Puppet::Type.newtype(:aptly_publish) do
     newvalues(:repo, :snapshot)
     defaultto :snapshot
   end
+
+  newparam(:distribution) do
+    desc 'Distribution name to publish'
+    validate do |value|
+      unless value.instance_of? String
+        raise ArgumentError, '%s is not a valid distribution (should be a string)' % value
+      end
+    end
+    defaultto ''
+  end
 end

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -4,17 +4,18 @@
 #
 define aptly::publish (
   $source_type,
-  $source_name = $name,
-  $ensure      = 'present',
+  $distribution = "${::lsbdistcodename}-${name}",
+  $ensure       = 'present',
 ) {
   validate_string(
     $source_type,
-    $source_name
+    $distribution
   )
 
-  aptly_publish { $source_name:
-    ensure      => $ensure,
-    source_type => $source_type,
-    notify      => Class['aptly::service'],
+  aptly_publish { $name:
+    ensure       => $ensure,
+    source_type  => $source_type,
+    distribution => $distribution,
+    notify       => Class['aptly::service'],
   }
 }

--- a/spec/defines/publish_spec.rb
+++ b/spec/defines/publish_spec.rb
@@ -6,7 +6,8 @@ describe 'aptly::publish' do
     let(:params) do
       {
         source_type: 'snapshot',
-        source_name: '2016-07-30-daily-snapshot'
+        distribution: 'jessie-2016-07-30-daily-snapshot',
+        name: '2016-07-30-daily-snapshot'
       }
     end
 

--- a/spec/unit/puppet/provider/aptly_publish_spec.rb
+++ b/spec/unit/puppet/provider/aptly_publish_spec.rb
@@ -6,7 +6,8 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
     Puppet::Type.type(:aptly_publish).new(
       name: 'test-snap',
       ensure: 'present',
-      source_type: :snapshot
+      source_type: :snapshot,
+      distribution: 'jessie-test-snap'
     )
   end
 
@@ -25,7 +26,8 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
       Puppet_X::Aptly::Cli.expects(:execute).with(
         object: :publish,
         action: :snapshot,
-        arguments: ['test-snap']
+        arguments: ['test-snap'],
+        flags: { 'distribution' => 'jessie-test-snap' }
       )
       provider.create
     end


### PR DESCRIPTION
Please make `distribution` configurable otherwise `$::lsbdistcodename` would be the default and you are not able to publish multiple repositories like `debian-backports`, `debian-security`, ...