### PR TITLE
Provide UID/GID, because CLI should not be executed as user root

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,18 +494,26 @@ Default : `true`
 
 #### Define aptly::mirror
 
-##### `location`
-
-Location of the repository to mirror.
-
-Default: `undef`
-
 ##### `ensure`
 
 Ensures if the mirror must be `present` (should exist) or `absent` (or be
 destroyed).
 
 Default: `present`
+
+##### `uid`
+
+UID of the OS user which will run the cli
+
+##### `gid`
+
+GID of the OS user which will run the cli
+
+##### `location`
+
+Location of the repository to mirror.
+
+Default: `undef`
 
 ##### `distribution`
 
@@ -546,6 +554,14 @@ destroyed).
 
 Default: `present`
 
+##### `uid`
+
+UID of the OS user which will run the cli
+
+##### `gid`
+
+GID of the OS user which will run the cli
+
 ##### `default_distribution`
 
 Default distribution (used only when publishing).
@@ -559,6 +575,21 @@ Default component (used only when publishing).
 Default: `main`
 
 #### Define aptly::snapshot
+
+##### `ensure`
+
+Ensures if the snapshot must be `present` (should exist) or `absent` (or be
+destroyed).
+
+Default: `present`
+
+##### `uid`
+
+UID of the OS user which will run the cli
+
+##### `gid`
+
+GID of the OS user which will run the cli
 
 ##### `source_type`
 
@@ -576,14 +607,22 @@ Name of the source to create snapshot from.
 
 Default: `undef`
 
+#### Define aptly::publish
+
 ##### `ensure`
 
-Ensures if the snapshot must be `present` (should exist) or `absent` (or be
+Ensures that the publication is `present` (should exist) or `absent` (or should be
 destroyed).
 
 Default: `present`
 
-#### Define aptly::publish
+##### `uid`
+
+UID of the OS user which will run the cli
+
+##### `gid`
+
+GID of the OS user which will run the cli
 
 ##### `source_type`
 
@@ -599,15 +638,6 @@ Default: `undef`
 Distribution name to publish.
 
 Default: `"${::lsbdistcodename}-${name}"`
-
-##### `ensure`
-
-Ensures that the publication is `present` (should exist) or `absent` (or should be
-destroyed).
-
-Default: `present`
-
-
 
 ## Limitations
 

--- a/lib/puppet/provider/aptly_mirror/cli.rb
+++ b/lib/puppet/provider/aptly_mirror/cli.rb
@@ -9,6 +9,8 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
   def create
     Puppet.info("Creating Aptly Mirror #{name}")
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :mirror,
       action: 'create',
       arguments: [name, resource[:location], resource[:distribution], [resource[:components]].join(' ')],
@@ -22,6 +24,8 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
     if resource[:update]
       Puppet.info("Updating Aptly Mirror #{name}")
       Puppet_X::Aptly::Cli.execute(
+        uid: resource[:uid],
+        gid: resource[:gid],
         object: :mirror,
         action: 'update',
         arguments: [name]
@@ -35,6 +39,8 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
     optsforce = resource[:force] ? 'force' : ''
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :mirror,
       action: 'drop',
       arguments: [name],
@@ -46,6 +52,8 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
     Puppet.debug("Check if #{name} exists")
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :mirror,
       action: 'list',
       flags: { 'raw' => 'true' },

--- a/lib/puppet/provider/aptly_publish/cli.rb
+++ b/lib/puppet/provider/aptly_publish/cli.rb
@@ -10,6 +10,8 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
     Puppet.info("Publishing Aptly #{resource[:source_type]} #{name}")
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :publish,
       action: resource[:source_type],
       arguments: [name],
@@ -21,6 +23,8 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
     Puppet.info("Destroying Aptly Publish #{name}")
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :publish,
       action: 'drop',
       arguments: [name],
@@ -32,6 +36,8 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
     Puppet.debug("Check if #{name} exists")
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :publish,
       action: 'list',
       flags: { 'raw' => 'true' },

--- a/lib/puppet/provider/aptly_repo/cli.rb
+++ b/lib/puppet/provider/aptly_repo/cli.rb
@@ -10,6 +10,8 @@ Puppet::Type.type(:aptly_repo).provide(:cli) do
     Puppet.info("Creating Aptly Repository #{name}")
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :repo,
       action: 'create',
       arguments: [name],
@@ -24,6 +26,8 @@ Puppet::Type.type(:aptly_repo).provide(:cli) do
     Puppet.info("Destroying Aptly Repository #{name}")
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :repo,
       action: 'drop',
       arguments: [name],
@@ -35,6 +39,8 @@ Puppet::Type.type(:aptly_repo).provide(:cli) do
     Puppet.debug("Check if Repository #{name} exists")
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :repo,
       action: 'list',
       flags: { 'raw' => 'true' },

--- a/lib/puppet/provider/aptly_snapshot/cli.rb
+++ b/lib/puppet/provider/aptly_snapshot/cli.rb
@@ -21,6 +21,8 @@ Puppet::Type.type(:aptly_snapshot).provide(:cli) do
     end
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :snapshot,
       action: 'create',
       arguments: [name, from, resource[:source_name]]
@@ -31,6 +33,8 @@ Puppet::Type.type(:aptly_snapshot).provide(:cli) do
     Puppet.info("Destroying Aptly Snapshot #{name}")
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :snapshot,
       action: 'drop',
       arguments: [name]
@@ -41,6 +45,8 @@ Puppet::Type.type(:aptly_snapshot).provide(:cli) do
     Puppet.debug("Check if #{name} exists")
 
     Puppet_X::Aptly::Cli.execute(
+      uid: resource[:uid],
+      gid: resource[:gid],
       object: :snapshot,
       action: 'list',
       flags: { 'raw' => 'true' },

--- a/lib/puppet/type/aptly_mirror.rb
+++ b/lib/puppet/type/aptly_mirror.rb
@@ -20,6 +20,16 @@ Puppet::Type.newtype(:aptly_mirror) do
     defaultto :true
   end
 
+  newparam(:uid) do
+    desc 'UID of the OS user which will run the cli'
+    defaultto '450'
+  end
+
+  newparam(:gid) do
+    desc 'GID of the OS user which will run the cli'
+    defaultto '450'
+  end
+
   newparam(:location) do
     desc 'The URL for the source Debian repository'
     validate do |value|
@@ -40,13 +50,13 @@ Puppet::Type.newtype(:aptly_mirror) do
     defaultto :undef
   end
 
-  newparam(:components, array_matching: :all) do
-    desc 'List of APT Debian components requested. Example : main'
+  newparam(:architectures, array_matching: :all) do
+    desc 'List of architectures to mirror'
     defaultto :undef
   end
 
-  newparam(:architectures, array_matching: :all) do
-    desc 'List of architectures to mirror'
+  newparam(:components, array_matching: :all) do
+    desc 'List of APT Debian components requested. Example : main'
     defaultto :undef
   end
 

--- a/lib/puppet/type/aptly_publish.rb
+++ b/lib/puppet/type/aptly_publish.rb
@@ -15,6 +15,16 @@ Puppet::Type.newtype(:aptly_publish) do
     defaultto :true
   end
 
+  newparam(:uid) do
+    desc 'UID of the OS user which will run the cli'
+    defaultto '450'
+  end
+
+  newparam(:gid) do
+    desc 'GID of the OS user which will run the cli'
+    defaultto '450'
+  end
+
   newparam(:source_type) do
     desc 'Type of the source for the snapshot : repository or snapshot'
     newvalues(:repo, :snapshot)

--- a/lib/puppet/type/aptly_repo.rb
+++ b/lib/puppet/type/aptly_repo.rb
@@ -15,14 +15,14 @@ Puppet::Type.newtype(:aptly_repo) do
     defaultto :true
   end
 
-  newparam(:default_component) do
-    desc 'Default component when publishing. Example : main'
-    validate do |value|
-      unless value.instance_of? String
-        raise ArgumentError, '%s is not a valid component (should be a string)' % value
-      end
-    end
-    defaultto 'main'
+  newparam(:uid) do
+    desc 'UID of the OS user which will run the cli'
+    defaultto '450'
+  end
+
+  newparam(:gid) do
+    desc 'GID of the OS user which will run the cli'
+    defaultto '450'
   end
 
   newparam(:default_distribution) do
@@ -33,5 +33,15 @@ Puppet::Type.newtype(:aptly_repo) do
       end
     end
     defaultto ''
+  end
+
+  newparam(:default_component) do
+    desc 'Default component when publishing. Example : main'
+    validate do |value|
+      unless value.instance_of? String
+        raise ArgumentError, '%s is not a valid component (should be a string)' % value
+      end
+    end
+    defaultto 'main'
   end
 end

--- a/lib/puppet/type/aptly_snapshot.rb
+++ b/lib/puppet/type/aptly_snapshot.rb
@@ -15,6 +15,16 @@ Puppet::Type.newtype(:aptly_snapshot) do
     defaultto :true
   end
 
+  newparam(:uid) do
+    desc 'UID of the OS user which will run the cli'
+    defaultto '450'
+  end
+
+  newparam(:gid) do
+    desc 'GID of the OS user which will run the cli'
+    defaultto '450'
+  end
+
   newparam(:source_type) do
     desc 'Type of the source for the snapshot : mirror, repo, or empty. Defaults to repository.'
     newvalues(:mirror, :repository, :empty)

--- a/lib/puppet_x/aptly/cli.rb
+++ b/lib/puppet_x/aptly/cli.rb
@@ -28,6 +28,8 @@ module Puppet_X
       #
       # @return [String] or an exception in case of error
       def self.execute(options = {})
+        uid = options.fetch(:uid)
+        gid = options.fetch(:gid)
         object = options.fetch(:object, :mirror)
         action = options.fetch(:action, '')
         exceptions = options.fetch(:exceptions, :true)
@@ -43,7 +45,7 @@ module Puppet_X
 
         begin
           Puppet.debug("Executing: #{cmd}")
-          result = Puppet::Util::Execution.execute(cmd)
+          result = Puppet::Util::Execution.execute(cmd, uid: uid, gid: gid)
         rescue => e
           raise Puppet::Error, e.message if exceptions
           e.message

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -5,6 +5,8 @@
 define aptly::mirror (
   $location,
   $ensure        = 'present',
+  $uid           = '450',
+  $gid           = '450',
   $distribution  = $::lsbdistcodename,
   $architectures = [],
   $components    = [],
@@ -24,6 +26,8 @@ define aptly::mirror (
 
   aptly_mirror { $name:
     ensure        => $ensure,
+    uid           => $uid,
+    gid           => $gid,
     location      => $location,
     distribution  => $distribution,
     architectures => $architectures,

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -4,8 +4,10 @@
 #
 define aptly::publish (
   $source_type,
-  $distribution = "${::lsbdistcodename}-${name}",
   $ensure       = 'present',
+  $uid          = '450',
+  $gid          = '450',
+  $distribution = "${::lsbdistcodename}-${name}",
 ) {
   validate_string(
     $source_type,
@@ -14,6 +16,8 @@ define aptly::publish (
 
   aptly_publish { $name:
     ensure       => $ensure,
+    uid          => $uid,
+    gid          => $gid,
     source_type  => $source_type,
     distribution => $distribution,
     notify       => Class['aptly::service'],

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,6 +4,8 @@
 #
 define aptly::repo (
   $ensure               = 'present',
+  $uid                  = '450',
+  $gid                  = '450',
   $default_distribution = $::lsbdistcodename,
   $default_component    = 'main',
 ) {
@@ -14,6 +16,8 @@ define aptly::repo (
 
   aptly_repo { $name:
     ensure               => $ensure,
+    uid                  => $uid,
+    gid                  => $gid,
     default_distribution => $default_distribution,
     default_component    => $default_component,
   }

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -7,6 +7,8 @@ define aptly::snapshot (
   $source_type,
   $source_name,
   $ensure = 'present',
+  $uid    = '450',
+  $gid    = '450',
 ) {
   validate_string(
     $source_type,
@@ -15,6 +17,8 @@ define aptly::snapshot (
 
   aptly_snapshot { $name:
     ensure      => $ensure,
+    uid         => $uid,
+    gid         => $gid,
     source_type => $source_type,
     source_name => $source_name,
   }

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -351,7 +351,7 @@ describe 'aptly', type: :class do
     context 'Enable no-lock on the API' do
       let(:params)  { { enable_api: true, api_nolock: true } }
       it { is_expected.to contain_service('aptly-api').with_ensure('running') }
-      
+
       it do
         is_expected.to create_file('/etc/init.d/aptly-api')\
           .with_mode('0755')\

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -5,6 +5,8 @@ describe 'aptly::mirror' do
     let(:title) { 'debian-main' }
     let(:params) do
       {
+        uid: '450',
+        gid: '450',
         location: 'http://ftp.us.debian.org/debian',
         distribution: 'jessie',
         architectures: %w(amd64 i386),
@@ -17,6 +19,8 @@ describe 'aptly::mirror' do
     it 'should call the aptly_mirror provider' do
       should contain_aptly_mirror('debian-main')\
         .with_ensure('present')\
+        .with_uid('450')\
+        .with_gid('450')\
         .with_location('http://ftp.us.debian.org/debian')\
         .with_distribution('jessie')\
         .with_architectures(%w(amd64 i386))\
@@ -30,6 +34,8 @@ describe 'aptly::mirror' do
     let(:title) { 'debian-main' }
     let(:params) do
       {
+        uid: '450',
+        gid: '450',
         location: 'my_bad_location',
         distribution: 'jessie',
         architectures: %w(amd64 i386),

--- a/spec/defines/publish_spec.rb
+++ b/spec/defines/publish_spec.rb
@@ -5,6 +5,8 @@ describe 'aptly::publish' do
     let(:title) { '2016-07-30-daily' }
     let(:params) do
       {
+        uid: '450',
+        gid: '450',
         source_type: 'snapshot',
         distribution: 'jessie-2016-07-30-daily-snapshot',
         name: '2016-07-30-daily-snapshot'
@@ -14,6 +16,8 @@ describe 'aptly::publish' do
     it 'should call the aptly_publish provider' do
       is_expected.to contain_aptly_publish('2016-07-30-daily-snapshot')\
         .with_ensure('present')\
+        .with_uid('450')\
+        .with_gid('450')\
         .with_source_type('snapshot')
     end
   end

--- a/spec/defines/repo_spec.rb
+++ b/spec/defines/repo_spec.rb
@@ -5,6 +5,8 @@ describe 'aptly::repo' do
     let(:title) { 'my_custom_repo' }
     let(:params) do
       {
+        uid: '450',
+        gid: '450',
         default_component: 'stable',
         default_distribution: 'xenial'
       }
@@ -13,6 +15,8 @@ describe 'aptly::repo' do
     it 'should call the aptly_repo provider' do
       is_expected.to contain_aptly_repo('my_custom_repo')\
         .with_ensure('present')\
+        .with_uid('450')\
+        .with_gid('450')\
         .with_default_component('stable')\
         .with_default_distribution('xenial')
     end

--- a/spec/defines/snapshot_spec.rb
+++ b/spec/defines/snapshot_spec.rb
@@ -5,6 +5,8 @@ describe 'aptly::snapshot' do
     let(:title) { '2016-07-30-daily' }
     let(:params) do
       {
+        uid: '450',
+        gid: '450',
         source_type: 'repository',
         source_name: 'debian-main'
       }
@@ -13,6 +15,8 @@ describe 'aptly::snapshot' do
     it 'should call the aptly_snapshot provider' do
       should contain_aptly_snapshot('2016-07-30-daily')\
         .with_ensure('present')\
+        .with_uid('450')\
+        .with_gid('450')\
         .with_source_type('repository')\
         .with_source_name('debian-main')
     end

--- a/spec/unit/puppet/provider/aptly_mirror_spec.rb
+++ b/spec/unit/puppet/provider/aptly_mirror_spec.rb
@@ -24,6 +24,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
   describe '#create' do
     it 'should create and update the mirror' do
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :mirror,
         action: 'create',
         arguments: ['debian-main', 'http://ftp.us.debian.org', 'test', 'undef'],
@@ -34,6 +36,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
         }
       )
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :mirror,
         action: 'update',
         arguments: ['debian-main']
@@ -43,6 +47,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
 
     it 'should not update when update is false' do
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :mirror,
         action: 'create',
         arguments: ['debian-main', 'http://ftp.us.debian.org', 'test', 'undef'],
@@ -53,6 +59,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
         }
       )
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :mirror,
         action: 'update',
         arguments: ['debian-main']
@@ -71,6 +79,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
   describe '#destroy' do
     it 'should drop the mirror' do
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :mirror,
         action: 'drop',
         arguments: ['debian-main'],
@@ -83,6 +93,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
   describe '#exists?' do
     it 'should check the mirror list' do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :mirror,
         action: 'list',
         flags: { 'raw' => 'true' },
@@ -92,6 +104,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
     end
     it 'should handle without mirror' do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :mirror,
         action: 'list',
         flags: { 'raw' => 'true' },

--- a/spec/unit/puppet/provider/aptly_publish_spec.rb
+++ b/spec/unit/puppet/provider/aptly_publish_spec.rb
@@ -24,6 +24,8 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
   describe '#create' do
     it 'should publish the snapshot' do
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :publish,
         action: :snapshot,
         arguments: ['test-snap'],
@@ -36,6 +38,8 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
   describe '#destroy' do
     it 'should drop the publication' do
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :publish,
         action: 'drop',
         arguments: ['test-snap'],
@@ -48,6 +52,8 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
   describe '#exists?' do
     it 'should check the publications list' do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :publish,
         action: 'list',
         flags: { 'raw' => 'true' },
@@ -57,6 +63,8 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
     end
     it 'should handle empty publications' do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :publish,
         action: 'list',
         flags: { 'raw' => 'true' },

--- a/spec/unit/puppet/provider/aptly_repo_spec.rb
+++ b/spec/unit/puppet/provider/aptly_repo_spec.rb
@@ -22,6 +22,8 @@ describe Puppet::Type.type(:aptly_repo).provider(:cli) do
   describe '#create' do
     it 'should create the repo' do
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :repo,
         action: 'create',
         arguments: ['foo'],
@@ -37,6 +39,8 @@ describe Puppet::Type.type(:aptly_repo).provider(:cli) do
   describe '#destroy' do
     it 'should drop the repo' do
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :repo,
         action: 'drop',
         arguments: ['foo'],
@@ -49,6 +53,8 @@ describe Puppet::Type.type(:aptly_repo).provider(:cli) do
   describe '#exists?' do
     it 'should check the repo list' do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :repo,
         action: 'list',
         flags: { 'raw' => 'true' },
@@ -58,6 +64,8 @@ describe Puppet::Type.type(:aptly_repo).provider(:cli) do
     end
     it 'should handle without repo' do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :repo,
         action: 'list',
         flags: { 'raw' => 'true' },

--- a/spec/unit/puppet/provider/aptly_snapshot_spec.rb
+++ b/spec/unit/puppet/provider/aptly_snapshot_spec.rb
@@ -24,6 +24,8 @@ describe Puppet::Type.type(:aptly_snapshot).provider(:cli) do
   describe '#create' do
     it 'should create the snapshot' do
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :snapshot,
         action: 'create',
         arguments: ['2016-07-30-daily', 'from repo', 'test']
@@ -35,6 +37,8 @@ describe Puppet::Type.type(:aptly_snapshot).provider(:cli) do
   describe '#destroy' do
     it 'should drop the snapshot' do
       Puppet_X::Aptly::Cli.expects(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :snapshot,
         action: 'drop',
         arguments: ['2016-07-30-daily']
@@ -46,6 +50,8 @@ describe Puppet::Type.type(:aptly_snapshot).provider(:cli) do
   describe '#exists?' do
     it 'should check the snapshot list' do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :snapshot,
         action: 'list',
         flags: { 'raw' => 'true' },
@@ -55,6 +61,8 @@ describe Puppet::Type.type(:aptly_snapshot).provider(:cli) do
     end
     it 'should handle without snapshot' do
       Puppet_X::Aptly::Cli.stubs(:execute).with(
+        uid: '450',
+        gid: '450',
         object: :snapshot,
         action: 'list',
         flags: { 'raw' => 'true' },

--- a/spec/unit/puppet_x/aptly/cli_spec.rb
+++ b/spec/unit/puppet_x/aptly/cli_spec.rb
@@ -15,6 +15,8 @@ describe Puppet_X::Aptly::Cli do
       [:mirror, :repo, :snapshot, :publish, :package, :db].each do |objname|
         it "should accept #{objname}" do
           expect(Puppet_X::Aptly::Cli.execute(
+                   uid: '450',
+                   gid: '450',
                    object: objname
           )).to eq("aptly  #{objname}")
         end
@@ -24,6 +26,8 @@ describe Puppet_X::Aptly::Cli do
     describe 'action parameter' do
       it 'should accept it' do
         expect(Puppet_X::Aptly::Cli.execute(
+                 uid: '450',
+                 gid: '450',
                  object: :publish,
                  action: 'list'
         )).to eq('aptly  publish list')
@@ -33,6 +37,8 @@ describe Puppet_X::Aptly::Cli do
     describe 'arguments parameter' do
       it 'should accept an array' do
         expect(Puppet_X::Aptly::Cli.execute(
+                 uid: '450',
+                 gid: '450',
                  object: :mirror,
                  action: 'create',
                  arguments: ['debian-main', 'http://ftp.us.debian.org']
@@ -43,6 +49,8 @@ describe Puppet_X::Aptly::Cli do
     describe 'flags parameter' do
       it 'should accept a Hash' do
         expect(Puppet_X::Aptly::Cli.execute(
+                 uid: '450',
+                 gid: '450',
                  object: :mirror,
                  action: 'create',
                  arguments: ['debian-main', 'http://ftp.us.debian.org'],


### PR DESCRIPTION
Please provide the UID/GID, because the CLI should not be executed as user root. Otherwise several files at `/var/aptly/db` belong to the wrong user and Puppet will fix this every 30 minutes.

```
==> default: Notice: Compiled catalog for debian-8.vagrant.dev in environment dev in 1.05 seconds
==> default: Info: Applying configuration version '1483997919'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/000016.log]/owner: owner changed 'root' to 'aptly'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/000016.log]/group: group changed 'root' to 'aptly'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/CURRENT]/owner: owner changed 'root' to 'aptly'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/CURRENT]/group: group changed 'root' to 'aptly'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/LOG]/owner: owner changed 'root' to 'aptly'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/LOG]/group: group changed 'root' to 'aptly'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/LOG.old]/owner: owner changed 'root' to 'aptly'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/LOG.old]/group: group changed 'root' to 'aptly'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/MANIFEST-000017]/owner: owner changed 'root' to 'aptly'
==> default: Notice: /Stage[main]/Aptly::Config/File[/var/aptly/db/MANIFEST-000017]/group: group changed 'root' to 'aptly'
```

I wish there would be a way to access the variables `$uid` and `$gid` from `init.pp`. Maybe someone else has better Ruby skills?