### PR TITLE
Update defaults on UID and GID added in #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,9 +505,13 @@ Default: `present`
 
 UID of the OS user which will run the cli
 
+Default: `450`
+
 ##### `gid`
 
 GID of the OS user which will run the cli
+
+Default: `450`
 
 ##### `location`
 
@@ -558,9 +562,13 @@ Default: `present`
 
 UID of the OS user which will run the cli
 
+Default: `450`
+
 ##### `gid`
 
 GID of the OS user which will run the cli
+
+Default: `450`
 
 ##### `default_distribution`
 
@@ -587,9 +595,13 @@ Default: `present`
 
 UID of the OS user which will run the cli
 
+Default: `450`
+
 ##### `gid`
 
 GID of the OS user which will run the cli
+
+Default: `450`
 
 ##### `source_type`
 
@@ -620,9 +632,13 @@ Default: `present`
 
 UID of the OS user which will run the cli
 
+Default: `450`
+
 ##### `gid`
 
 GID of the OS user which will run the cli
+
+Default: `450`
 
 ##### `source_type`
 


### PR DESCRIPTION
I only saw after merging #42 that the defaults were not added to the doc.
This PR adds them.