### PR TITLE
Add default keyring path for aptly mirror resource

### DIFF
--- a/lib/puppet/provider/aptly_mirror/cli.rb
+++ b/lib/puppet/provider/aptly_mirror/cli.rb
@@ -17,7 +17,8 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
       flags: {
         'architectures' => [resource[:architectures]].join(','),
         'with-sources'  => resource[:with_sources],
-        'with-udebs'    => resource[:with_udebs]
+        'with-udebs'    => resource[:with_udebs],
+        'keyring'       => resource[:keyring]
       }
     )
 

--- a/lib/puppet/type/aptly_mirror.rb
+++ b/lib/puppet/type/aptly_mirror.rb
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:aptly_mirror) do
   end
 
   newparam(:keyring) do
-    desc 'Set path to keyring. Default - /etc/apt/trusted.gpg'
+    desc 'Set path to keyring. Default /etc/apt/trusted.gpg'
     defaultto "/etc/apt/trusted.gpg"
   end
 

--- a/lib/puppet/type/aptly_mirror.rb
+++ b/lib/puppet/type/aptly_mirror.rb
@@ -60,6 +60,11 @@ Puppet::Type.newtype(:aptly_mirror) do
     defaultto :undef
   end
 
+  newparam(:keyring) do
+    desc 'Set path to keyring. Default - /etc/apt/trusted.gpg'
+    defaultto "/etc/apt/trusted.gpg"
+  end
+
   newparam(:with_sources, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc 'Whether to mirror the source packages or not'
     defaultto :false

--- a/lib/puppet_x/aptly/cli.rb
+++ b/lib/puppet_x/aptly/cli.rb
@@ -50,7 +50,6 @@ module Puppet_X
         begin
           Puppet.debug("Executing: #{cmd}")
           result = Puppet::Util::Execution.execute(cmd, uid: uid, gid: gid)
-          Puppet.debug("Command output: #{result}")
         rescue => e
           raise Puppet::Error, e.message if exceptions
           e.message

--- a/lib/puppet_x/aptly/cli.rb
+++ b/lib/puppet_x/aptly/cli.rb
@@ -50,6 +50,7 @@ module Puppet_X
         begin
           Puppet.debug("Executing: #{cmd}")
           result = Puppet::Util::Execution.execute(cmd, uid: uid, gid: gid)
+          Puppet.debug("Command output: #{result}")
         rescue => e
           raise Puppet::Error, e.message if exceptions
           e.message

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -12,6 +12,7 @@ define aptly::mirror (
   $components    = [],
   $with_sources  = false,
   $with_udebs    = false,
+  $keyring       = '/etc/apt/trusted.gpg'
 ) {
   validate_string( $distribution)
   validate_array(


### PR DESCRIPTION
If you don't set keyring aptly can't mirror repo because it trying to find keyrings in aptly home dir. This pull request fix it.