### PR TITLE
Add manage_user parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,11 @@ Path of the configuration file to be used by the aptly service.
 
 Default: `/etc/aptly.conf`
 
+##### `manage_user`
+Whethere should this module manage aptly user or not
+
+Default: `true`
+
 ##### `user`
 
 OS user which will run the service.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class aptly (
   $port                 = $aptly::params::port,
   $bind                 = $aptly::params::bind,
   $config_filepath      = $aptly::params::config_filepath,
+  $manage_user          = $aptly::params::manage_user,
   $user                 = $aptly::params::user,
   $uid                  = $aptly::params::uid,
   $group                = $aptly::params::group,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@
 #
 class aptly::install {
 
-  if $manage_user {
+  if $aptly::manage_user {
     user { $aptly::user:
       ensure  => present,
       uid     => $aptly::uid,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@
 #
 class aptly::install {
 
-  if ! defined(User[$aptly::user]) {
+  if $manage_user {
     user { $aptly::user:
       ensure  => present,
       uid     => $aptly::uid,
@@ -12,9 +12,7 @@ class aptly::install {
       shell   => '/bin/bash',
       require => Group[$aptly::group],
     }
-  }
 
-  if ! defined(Group[$aptly::group]) {
     group { $aptly::group:
       ensure => present,
       gid    => $aptly::gid,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class aptly::params {
   $port            = '8080'
   $bind            = '0.0.0.0'
   $config_filepath = '/etc/aptly.conf'
+  $manage_user     = true,
   $user            = 'aptly'
   $uid             = 450
   $group           = 'aptly'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@ class aptly::params {
   $port            = '8080'
   $bind            = '0.0.0.0'
   $config_filepath = '/etc/aptly.conf'
-  $manage_user     = true,
+  $manage_user     = true
   $user            = 'aptly'
   $uid             = 450
   $group           = 'aptly'


### PR DESCRIPTION
Sometimes we just want to specify aptly user without managing it.
This PR also removes ugly `if ! defined` hack