### PR TITLE
make root_dir recursion configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@ class aptly::config {
   file { $aptly::root_dir:
     ensure  => directory,
     mode    => '0644',
-    recurse => true,
+    recurse => $aptly::recurse_root_dir,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class aptly (
   $api_bind             = $aptly::params::api_bind,
   $api_nolock           = $aptly::params::api_nolock,
   $manage_xz_utils      = $aptly::params::manage_xz_utils,
+  $recurse_root_dir     = $aptly::params::recurse_root_dir,
 ) inherits aptly::params {
 
   validate_string(
@@ -52,7 +53,8 @@ class aptly (
     $install_repo,
     $enable_service,
     $enable_api,
-    $api_nolock)
+    $api_nolock,
+    $recurse_root_dir)
   validate_array($architectures)
   validate_hash($properties)
   validate_hash($s3_publish_endpoints)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,4 +42,5 @@ class aptly::params {
   $api_bind             = '0.0.0.0'
   $api_nolock           = false
   $manage_xz_utils      = true
+  $recurse_root_dir     = true
 }

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -110,8 +110,7 @@ describe 'aptly', type: :class do
             with_ensure('directory').\
             with_mode('0644').\
             with_owner('aptly').\
-            with_group('aptly').\
-            with_recurse(true)
+            with_group('aptly')
         end
       end
     end


### PR DESCRIPTION
Recursive management of directories with many files (like repository mirrors) consumes large amounts of memory during Puppet runs.