### PR TITLE
update repository key repo.aptly.info

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,8 +9,8 @@ class aptly::params {
   $repo_location   = 'http://repo.aptly.info'
   $repo_release    = 'squeeze'
   $repo_repos      = 'main'
-  $repo_keyserver  = 'keys.gnupg.net'
-  $repo_key        = 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460'
+  $repo_keyserver  = 'pool.sks-keyservers.net'
+  $repo_key        = '26DA9D8630302E0B86A7A2CBED75B5A4483DA07C'
   $enable_service  = true
   $port            = '8080'
   $bind            = '0.0.0.0'

--- a/spec/classes/aptly_spec.rb
+++ b/spec/classes/aptly_spec.rb
@@ -43,7 +43,7 @@ describe 'aptly', type: :class do
             with_location('http://repo.aptly.info').\
             with_release('squeeze').\
             with_repos('main').\
-            with_key('id' => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460', 'server' => 'keys.gnupg.net').\
+            with_key('id' => '26DA9D8630302E0B86A7A2CBED75B5A4483DA07C', 'server' => 'pool.sks-keyservers.net').\
             with_include('src' => false, 'deb' => true).\
             that_notifies('Class[apt::update]')
 


### PR DESCRIPTION
This PR updates the repository key of the repo.aptly.info repository, which has recently been replaced. 