### PR TITLE
ensure fixed order or params in /etc/aptly.conf

### DIFF
--- a/templates/aptly.conf.erb
+++ b/templates/aptly.conf.erb
@@ -1,7 +1,7 @@
 {
   "rootDir": "<%= scope.lookupvar('aptly::root_dir') -%>",
   "architectures": ["<%= scope.lookupvar('aptly::architectures').join('", "') %>"],
-<% scope.lookupvar('aptly::properties').each do |k, v| -%>
+<% scope.lookupvar('aptly::properties').sort.each do |k, v| -%>
   "<%= k -%>": <%= v %>,
 <% end -%>
   "ppaDistributorID": "<%= scope.lookupvar('aptly::ppa_dist') %>",


### PR DESCRIPTION
for some reason, the order of params retrieved by scope.lookupvar
is not sorted (at least in out environment)
there's always a change in order on every puppet run, which causes
an unfortunate api restart