### PR TITLE
Add config_filepath to aptly::repo

### DIFF
--- a/lib/puppet/provider/aptly_mirror/cli.rb
+++ b/lib/puppet/provider/aptly_mirror/cli.rb
@@ -17,7 +17,8 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
       flags: {
         'architectures' => [resource[:architectures]].join(','),
         'with-sources'  => resource[:with_sources],
-        'with-udebs'    => resource[:with_udebs]
+        'with-udebs'    => resource[:with_udebs],
+        'config'        => resource[:config_filepath],
       }
     )
 
@@ -28,7 +29,8 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
       gid: resource[:gid],
       object: :mirror,
       action: 'update',
-      arguments: [name]
+      arguments: [name],
+      flags: { 'config' => resource[:config_filepath] }
     )
   end
 
@@ -43,7 +45,7 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
       object: :mirror,
       action: 'drop',
       arguments: [name],
-      flags: { optsforce => '' }
+      flags: { optsforce => '', 'config' => resource[:config_filepath] }
     )
   end
 
@@ -55,7 +57,7 @@ Puppet::Type.type(:aptly_mirror).provide(:cli) do
       gid: resource[:gid],
       object: :mirror,
       action: 'list',
-      flags: { 'raw' => 'true' },
+      flags: { 'raw' => 'true', 'config' => resource[:config_filepath] },
       exceptions: false
     ).lines.map(&:chomp).include? name
   end

--- a/lib/puppet/provider/aptly_publish/cli.rb
+++ b/lib/puppet/provider/aptly_publish/cli.rb
@@ -15,7 +15,7 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
       object: :publish,
       action: resource[:source_type],
       arguments: [name],
-      flags: { 'distribution' => resource[:distribution] }
+      flags: { 'distribution' => resource[:distribution], 'config' => resource[:config_filepath] }
     )
   end
 
@@ -28,7 +28,7 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
       object: :publish,
       action: 'drop',
       arguments: [name],
-      flags: { 'force-drop' => resource[:force] ? 'true' : 'false' }
+      flags: { 'force-drop' => resource[:force] ? 'true' : 'false', 'config' => resource[:config_filepath] }
     )
   end
 
@@ -40,7 +40,7 @@ Puppet::Type.type(:aptly_publish).provide(:cli) do
       gid: resource[:gid],
       object: :publish,
       action: 'list',
-      flags: { 'raw' => 'true' },
+      flags: { 'raw' => 'true', 'config' => resource[:config_filepath] },
       exceptions: false
     ).lines.map(&:chomp).include? name
   end

--- a/lib/puppet/provider/aptly_repo/cli.rb
+++ b/lib/puppet/provider/aptly_repo/cli.rb
@@ -17,7 +17,8 @@ Puppet::Type.type(:aptly_repo).provide(:cli) do
       arguments: [name],
       flags: {
         'component'    => resource[:default_component],
-        'distribution' => resource[:default_distribution]
+        'distribution' => resource[:default_distribution],
+        'config'       => resource[:config_filepath]
       }
     )
   end
@@ -31,7 +32,7 @@ Puppet::Type.type(:aptly_repo).provide(:cli) do
       object: :repo,
       action: 'drop',
       arguments: [name],
-      flags: { 'force' => resource[:force] ? 'true' : 'false' }
+      flags: { 'force' => resource[:force] ? 'true' : 'false', 'config' => resource[:config_filepath] }
     )
   end
 
@@ -43,7 +44,7 @@ Puppet::Type.type(:aptly_repo).provide(:cli) do
       gid: resource[:gid],
       object: :repo,
       action: 'list',
-      flags: { 'raw' => 'true' },
+      flags: { 'raw' => 'true', 'config' => resource[:config_filepath] },
       exceptions: false
     ).lines.map(&:chomp).include? name
   end

--- a/lib/puppet/provider/aptly_snapshot/cli.rb
+++ b/lib/puppet/provider/aptly_snapshot/cli.rb
@@ -25,7 +25,8 @@ Puppet::Type.type(:aptly_snapshot).provide(:cli) do
       gid: resource[:gid],
       object: :snapshot,
       action: 'create',
-      arguments: [name, from, resource[:source_name]]
+      arguments: [name, from, resource[:source_name]],
+      flags: { 'config' => resource[:config_filepath] }
     )
   end
 
@@ -37,7 +38,8 @@ Puppet::Type.type(:aptly_snapshot).provide(:cli) do
       gid: resource[:gid],
       object: :snapshot,
       action: 'drop',
-      arguments: [name]
+      arguments: [name],
+      flags: { 'config' => resource[:config_filepath] }
     )
   end
 
@@ -49,7 +51,7 @@ Puppet::Type.type(:aptly_snapshot).provide(:cli) do
       gid: resource[:gid],
       object: :snapshot,
       action: 'list',
-      flags: { 'raw' => 'true' },
+      flags: { 'raw' => 'true', 'config' => resource[:config_filepath] },
       exceptions: false
     ).lines.map(&:chomp).include? name
   end

--- a/lib/puppet/type/aptly_mirror.rb
+++ b/lib/puppet/type/aptly_mirror.rb
@@ -30,6 +30,11 @@ Puppet::Type.newtype(:aptly_mirror) do
     defaultto '450'
   end
 
+  newparam(:config_filepath) do
+    desc 'Path of the configuration file to be used by the aptly service.'
+    defaultto '/etc/aptly.conf'
+  end
+
   newparam(:location) do
     desc 'The URL for the source Debian repository'
     validate do |value|

--- a/lib/puppet/type/aptly_publish.rb
+++ b/lib/puppet/type/aptly_publish.rb
@@ -25,6 +25,11 @@ Puppet::Type.newtype(:aptly_publish) do
     defaultto '450'
   end
 
+  newparam(:config_filepath) do
+    desc 'Path of the configuration file to be used by the aptly service.'
+    defaultto '/etc/aptly.conf'
+  end
+
   newparam(:source_type) do
     desc 'Type of the source for the snapshot : repository or snapshot'
     newvalues(:repo, :snapshot)

--- a/lib/puppet/type/aptly_repo.rb
+++ b/lib/puppet/type/aptly_repo.rb
@@ -25,6 +25,11 @@ Puppet::Type.newtype(:aptly_repo) do
     defaultto '450'
   end
 
+  newparam(:config_filepath) do
+    desc 'Path of the configuration file to be used by the aptly service.'
+    defaultto '/etc/aptly.conf'
+  end
+
   newparam(:default_distribution) do
     desc 'Default distribution when publishing'
     validate do |value|

--- a/lib/puppet/type/aptly_snapshot.rb
+++ b/lib/puppet/type/aptly_snapshot.rb
@@ -25,6 +25,11 @@ Puppet::Type.newtype(:aptly_snapshot) do
     defaultto '450'
   end
 
+  newparam(:config_filepath) do
+    desc 'Path of the configuration file to be used by the aptly service.'
+    defaultto '/etc/aptly.conf'
+  end
+
   newparam(:source_type) do
     desc 'Type of the source for the snapshot : mirror, repo, or empty. Defaults to repository.'
     newvalues(:mirror, :repository, :empty)

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -4,14 +4,15 @@
 #
 define aptly::mirror (
   $location,
-  $ensure        = 'present',
-  $uid           = '450',
-  $gid           = '450',
-  $distribution  = $::lsbdistcodename,
-  $architectures = [],
-  $components    = [],
-  $with_sources  = false,
-  $with_udebs    = false,
+  $ensure          = 'present',
+  $uid             = '450',
+  $gid             = '450',
+  $config_filepath = '/etc/aptly.conf',
+  $distribution    = $::lsbdistcodename,
+  $architectures   = [],
+  $components      = [],
+  $with_sources    = false,
+  $with_udebs      = false,
 ) {
   validate_string( $distribution)
   validate_array(
@@ -25,14 +26,15 @@ define aptly::mirror (
   validate_re($location, ['\Ahttps?:\/\/', '\Aftp:\/\/', '\A\/\w+'])
 
   aptly_mirror { $name:
-    ensure        => $ensure,
-    uid           => $uid,
-    gid           => $gid,
-    location      => $location,
-    distribution  => $distribution,
-    architectures => $architectures,
-    components    => $components,
-    with_sources  => $with_sources,
-    with_udebs    => $with_udebs,
+    ensure          => $ensure,
+    uid             => $uid,
+    gid             => $gid,
+    config_filepath => $config_filepath,
+    location        => $location,
+    distribution    => $distribution,
+    architectures   => $architectures,
+    components      => $components,
+    with_sources    => $with_sources,
+    with_udebs      => $with_udebs,
   }
 }

--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -4,10 +4,11 @@
 #
 define aptly::publish (
   $source_type,
-  $ensure       = 'present',
-  $uid          = '450',
-  $gid          = '450',
-  $distribution = "${::lsbdistcodename}-${name}",
+  $ensure          = 'present',
+  $uid             = '450',
+  $gid             = '450',
+  $config_filepath = '/etc/aptly.conf',
+  $distribution    = "${::lsbdistcodename}-${name}",
 ) {
   validate_string(
     $source_type,
@@ -15,11 +16,12 @@ define aptly::publish (
   )
 
   aptly_publish { $name:
-    ensure       => $ensure,
-    uid          => $uid,
-    gid          => $gid,
-    source_type  => $source_type,
-    distribution => $distribution,
-    notify       => Class['aptly::service'],
+    ensure          => $ensure,
+    uid             => $uid,
+    gid             => $gid,
+    config_filepath => $config_filepath,
+    source_type     => $source_type,
+    distribution    => $distribution,
+    notify          => Class['aptly::service'],
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,6 +6,7 @@ define aptly::repo (
   $ensure               = 'present',
   $uid                  = '450',
   $gid                  = '450',
+  $config_filepath      = '/etc/aptly.conf',
   $default_distribution = $::lsbdistcodename,
   $default_component    = 'main',
 ) {
@@ -18,6 +19,7 @@ define aptly::repo (
     ensure               => $ensure,
     uid                  => $uid,
     gid                  => $gid,
+    config_filepath      => $config_filepath,
     default_distribution => $default_distribution,
     default_component    => $default_component,
   }

--- a/manifests/snapshot.pp
+++ b/manifests/snapshot.pp
@@ -6,9 +6,10 @@
 define aptly::snapshot (
   $source_type,
   $source_name,
-  $ensure = 'present',
-  $uid    = '450',
-  $gid    = '450',
+  $ensure          = 'present',
+  $uid             = '450',
+  $gid             = '450',
+  $config_filepath = '/etc/aptly.conf',
 ) {
   validate_string(
     $source_type,
@@ -16,10 +17,11 @@ define aptly::snapshot (
   )
 
   aptly_snapshot { $name:
-    ensure      => $ensure,
-    uid         => $uid,
-    gid         => $gid,
-    source_type => $source_type,
-    source_name => $source_name,
+    ensure          => $ensure,
+    uid             => $uid,
+    gid             => $gid,
+    config_filepath => $config_filepath,
+    source_type     => $source_type,
+    source_name     => $source_name,
   }
 }

--- a/spec/unit/puppet/provider/aptly_mirror_spec.rb
+++ b/spec/unit/puppet/provider/aptly_mirror_spec.rb
@@ -32,7 +32,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
         flags: {
           'architectures' => 'undef',
           'with-sources'  => false,
-          'with-udebs'    => false
+          'with-udebs'    => false,
+          'config'        => '/etc/aptly.conf'
         }
       )
       Puppet_X::Aptly::Cli.expects(:execute).with(
@@ -40,7 +41,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
         gid: '450',
         object: :mirror,
         action: 'update',
-        arguments: ['debian-main']
+        arguments: ['debian-main'],
+        flags: { 'config' => '/etc/aptly.conf' }
       )
       provider.create
     end
@@ -55,7 +57,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
         flags: {
           'architectures' => 'undef',
           'with-sources'  => false,
-          'with-udebs'    => false
+          'with-udebs'    => false,
+          'config'        => '/etc/aptly.conf'
         }
       )
       Puppet_X::Aptly::Cli.expects(:execute).with(
@@ -63,7 +66,8 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
         gid: '450',
         object: :mirror,
         action: 'update',
-        arguments: ['debian-main']
+        arguments: ['debian-main'],
+        flags: { 'config' => '/etc/aptly.conf' }
       ).never
       resource2 = Puppet::Type.type(:aptly_mirror).new(
         name: 'debian-main',
@@ -84,7 +88,7 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
         object: :mirror,
         action: 'drop',
         arguments: ['debian-main'],
-        flags: { 'force' => '' }
+        flags: { 'force' => '', 'config' => '/etc/aptly.conf' }
       )
       provider.destroy
     end
@@ -97,7 +101,7 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
         gid: '450',
         object: :mirror,
         action: 'list',
-        flags: { 'raw' => 'true' },
+        flags: { 'raw' => 'true', 'config' => '/etc/aptly.conf' },
         exceptions: false
       ).returns "foo\ndebian-main\nbar"
       expect(provider.exists?).to eq(true)
@@ -108,7 +112,7 @@ describe Puppet::Type.type(:aptly_mirror).provider(:cli) do
         gid: '450',
         object: :mirror,
         action: 'list',
-        flags: { 'raw' => 'true' },
+        flags: { 'raw' => 'true', 'config' => '/etc/aptly.conf' },
         exceptions: false
       ).returns ''
       expect(provider.exists?).to eq(false)

--- a/spec/unit/puppet/provider/aptly_publish_spec.rb
+++ b/spec/unit/puppet/provider/aptly_publish_spec.rb
@@ -29,7 +29,7 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
         object: :publish,
         action: :snapshot,
         arguments: ['test-snap'],
-        flags: { 'distribution' => 'jessie-test-snap' }
+        flags: { 'distribution' => 'jessie-test-snap', 'config' => '/etc/aptly.conf' }
       )
       provider.create
     end
@@ -43,7 +43,7 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
         object: :publish,
         action: 'drop',
         arguments: ['test-snap'],
-        flags: { 'force-drop' => 'true' }
+        flags: { 'force-drop' => 'true', 'config' => '/etc/aptly.conf' }
       )
       provider.destroy
     end
@@ -56,7 +56,7 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
         gid: '450',
         object: :publish,
         action: 'list',
-        flags: { 'raw' => 'true' },
+        flags: { 'raw' => 'true', 'config' => '/etc/aptly.conf' },
         exceptions: false
       ).returns "foo\ntest-snap\nbar"
       expect(provider.exists?).to eq(true)
@@ -67,7 +67,7 @@ describe Puppet::Type.type(:aptly_publish).provider(:cli) do
         gid: '450',
         object: :publish,
         action: 'list',
-        flags: { 'raw' => 'true' },
+        flags: { 'raw' => 'true', 'config' => '/etc/aptly.conf' },
         exceptions: false
       ).returns ''
       expect(provider.exists?).to eq(false)

--- a/spec/unit/puppet/provider/aptly_repo_spec.rb
+++ b/spec/unit/puppet/provider/aptly_repo_spec.rb
@@ -28,8 +28,9 @@ describe Puppet::Type.type(:aptly_repo).provider(:cli) do
         action: 'create',
         arguments: ['foo'],
         flags: {
-          'component' => 'main',
-          'distribution' => ''
+          'component'    => 'main',
+          'distribution' => '',
+          'config'       => '/etc/aptly.conf'
         }
       )
       provider.create
@@ -44,7 +45,7 @@ describe Puppet::Type.type(:aptly_repo).provider(:cli) do
         object: :repo,
         action: 'drop',
         arguments: ['foo'],
-        flags: { 'force' => 'true' }
+        flags: { 'force' => 'true', 'config' => '/etc/aptly.conf' }
       )
       provider.destroy
     end
@@ -57,7 +58,7 @@ describe Puppet::Type.type(:aptly_repo).provider(:cli) do
         gid: '450',
         object: :repo,
         action: 'list',
-        flags: { 'raw' => 'true' },
+        flags: { 'raw' => 'true', 'config' => '/etc/aptly.conf' },
         exceptions: false
       ).returns "foo\ntest-snap\nbar"
       expect(provider.exists?).to eq(true)
@@ -68,7 +69,7 @@ describe Puppet::Type.type(:aptly_repo).provider(:cli) do
         gid: '450',
         object: :repo,
         action: 'list',
-        flags: { 'raw' => 'true' },
+        flags: { 'raw' => 'true', 'config' => '/etc/aptly.conf' },
         exceptions: false
       ).returns ''
       expect(provider.exists?).to eq(false)

--- a/spec/unit/puppet/provider/aptly_snapshot_spec.rb
+++ b/spec/unit/puppet/provider/aptly_snapshot_spec.rb
@@ -28,7 +28,8 @@ describe Puppet::Type.type(:aptly_snapshot).provider(:cli) do
         gid: '450',
         object: :snapshot,
         action: 'create',
-        arguments: ['2016-07-30-daily', 'from repo', 'test']
+        arguments: ['2016-07-30-daily', 'from repo', 'test'],
+        flags: { 'config' => '/etc/aptly.conf' }
       )
       provider.create
     end
@@ -41,7 +42,8 @@ describe Puppet::Type.type(:aptly_snapshot).provider(:cli) do
         gid: '450',
         object: :snapshot,
         action: 'drop',
-        arguments: ['2016-07-30-daily']
+        arguments: ['2016-07-30-daily'],
+        flags: { 'config' => '/etc/aptly.conf' }
       )
       provider.destroy
     end
@@ -54,7 +56,7 @@ describe Puppet::Type.type(:aptly_snapshot).provider(:cli) do
         gid: '450',
         object: :snapshot,
         action: 'list',
-        flags: { 'raw' => 'true' },
+        flags: { 'raw' => 'true', 'config' => '/etc/aptly.conf' },
         exceptions: false
       ).returns "foo\n2016-07-30-daily\nbar"
       expect(provider.exists?).to eq(true)
@@ -65,7 +67,7 @@ describe Puppet::Type.type(:aptly_snapshot).provider(:cli) do
         gid: '450',
         object: :snapshot,
         action: 'list',
-        flags: { 'raw' => 'true' },
+        flags: { 'raw' => 'true', 'config' => '/etc/aptly.conf' },
         exceptions: false
       ).returns ''
       expect(provider.exists?).to eq(false)


### PR DESCRIPTION
This is needed because otherwise the aptly command might run into
permission issue with the currenty $PWD. See #62 for more information.

Fixes #62.