### PR TITLE
Fix/update gpg key

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class aptly::params {
   $repo_release    = 'squeeze'
   $repo_repos      = 'main'
   $repo_keyserver  = 'keys.gnupg.net'
-  $repo_key        = 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460'
+  $repo_key        = '26DA9D8630302E0B86A7A2CBED75B5A4483DA07C'
   $enable_service  = true
   $port            = '8080'
   $bind            = '0.0.0.0'


### PR DESCRIPTION
The aptly signing key was updated.

This fixes #60.