### PR TITLE
Remove notify of aptly service

### DIFF
--- a/manifests/publish.pp
+++ b/manifests/publish.pp
@@ -20,6 +20,5 @@ define aptly::publish (
     gid          => $gid,
     source_type  => $source_type,
     distribution => $distribution,
-    notify       => Class['aptly::service'],
   }
 }


### PR DESCRIPTION
The aptly service does not need to be notified if a publish is notified.

Notifying it can even create loops if you let a `repo` resource depend on the main class and then create publishes that depend on the repo, you will end up with:

```
(Aptly_publish[dehydrated] => Class[Aptly::Service] => Service[aptly] => Class[Aptly::Service] => Class[Aptly] => Class[Aptly] => Aptly::Repo[dehydrated] => Aptly_repo[dehydrated] => Aptly::Repo[dehydrated] => Aptly::Publish[dehydrated] => Aptly_publish[dehydrated])
```